### PR TITLE
:sparkles: Added ArgoCD configuration and ingress

### DIFF
--- a/argocd/config/argocd-cmd-params-cm.yaml
+++ b/argocd/config/argocd-cmd-params-cm.yaml
@@ -1,0 +1,6 @@
+apiVersion: v1
+data:
+  server.insecure: "true"
+kind: ConfigMap
+metadata:
+  name: argocd-cmd-params-cm

--- a/argocd/ingress.yaml
+++ b/argocd/ingress.yaml
@@ -1,0 +1,24 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: argocd-server
+  namespace: argocd
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`argocd.mizar.scalar.cloud`)
+      priority: 10
+      services:
+        - name: argocd-server
+          port: 80
+    - kind: Rule
+      match: Host(`argocd.mizar.scalar.cloud`) && Header(`Content-Type`, `application/grpc`)
+      priority: 11
+      services:
+        - name: argocd-server
+          port: 80
+          scheme: h2c
+  tls:
+    certResolver: le-staging

--- a/argocd/kustomization.yaml
+++ b/argocd/kustomization.yaml
@@ -1,0 +1,12 @@
+kind: Kustomization
+resources:
+  - install.yaml
+  - ingress.yaml
+generatorOptions:
+  disableNameSuffixHash: true
+configMapGenerator:
+  - name: argocd-cmd-params-cm
+    behavior: replace
+    envs:
+      - config/argocd-cmd-params-cm.yaml
+apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
Introduced new configuration for ArgoCD with insecure server settings. Also, added an IngressRoute for the ArgoCD server with specific rules and services. Updated kustomization file to include these new resources and a ConfigMap generator.
