### PR TITLE
:bug: Fixed typo in TLS secret name field

### DIFF
--- a/argocd/ingress.yaml
+++ b/argocd/ingress.yaml
@@ -21,7 +21,7 @@ spec:
           port: 80
           scheme: h2c
   tls:
-    secret-name: argocd-tls
+    secretName: argocd-tls
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate


### PR DESCRIPTION
The commit corrects a typographical error in the TLS secret name field of the ingress.yaml file. The incorrect 'secret-name' has been replaced with the correct 'secretName'.
