### PR TITLE
:lock: Updated TLS secret and issuer reference

### DIFF
--- a/argocd/ingress.yaml
+++ b/argocd/ingress.yaml
@@ -29,9 +29,9 @@ metadata:
   name: argocd
   namespace: argocd
 spec:
-  secretName: argocd-tls        # <===  Name of secret where the generated certificate will be stored.
+  secretName: argocd-tls
   dnsNames:
     - "argocd.mizar.scalar.cloud"
   issuerRef:
-    name: le-staging
+    name: le-prod
     kind: ClusterIssuer


### PR DESCRIPTION
The TLS secret name in the ingress configuration has been cleaned up, removing an unnecessary comment. Additionally, the issuer reference has been switched from 'le-staging' to 'le-prod', indicating a move to production-level certificate issuing.
