### PR TITLE
:sparkles: Added new Kubernetes applications

### DIFF
--- a/apps/apps.yaml
+++ b/apps/apps.yaml
@@ -1,0 +1,18 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: apps
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+  source:
+    path: apps
+    repoURL: https://github.com/mizar-labs/mizar
+    targetRevision: HEAD
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/apps/argocd.yaml
+++ b/apps/argocd.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: argocd
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/mizar-labs/mizar
+    path: argocd
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: argocd
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
Two new Kubernetes applications have been added. The first application is configured to automatically sync with the source repository and self-heal if necessary. It also has a sync option to create its own namespace. The second application shares similar configurations but is specifically set up in the 'argocd' namespace. Both applications are part of the default project and target the HEAD revision of their respective paths in the source repository.
