### PR TITLE
:sparkles: Added new application and deployment configurations

### DIFF
--- a/apps/discollama.yaml
+++ b/apps/discollama.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: discollama
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+  source:
+    path: discollama
+    repoURL: https://github.com/mizar-labs/mizar
+    targetRevision: HEAD
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/discollama/deployment.yaml
+++ b/discollama/deployment.yaml
@@ -1,0 +1,44 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: discollama
+  namespace: discollama-bat
+  labels:
+    app: discollama
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: discollama
+  template:
+    metadata:
+      labels:
+        app: discollama
+      annotations:
+        dapr.io/app-id: prod-discollama
+        dapr.io/config: tracing
+        dapr.io/enable-api-logging: 'true'
+        dapr.io/enabled: 'true'
+    spec:
+      containers:
+        - name: discollama
+          image: quay.io/mightydjinn/discollama:v0.2.1
+          envFrom:
+            - secretRef:
+                name: discollama
+          resources: {}
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 25%
+      maxSurge: 25%
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600


### PR DESCRIPTION
Introduced a new Application configuration for the 'discollama' app in the ArgoCD namespace. This includes automated sync policy with prune and self-heal options, along with a CreateNamespace sync option.

Also added a Deployment configuration for 'discollama' in its own namespace. The deployment is configured with Dapr annotations, environment variables from secrets, rolling update strategy, and other standard Kubernetes settings.
