### PR TITLE
:sparkles: Added Tube Archivist application

### DIFF
--- a/apps/tube-archivist.yaml
+++ b/apps/tube-archivist.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tube-archivist
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+  source:
+    path: tube-archivist
+    repoURL: https://github.com/mizar-labs/mizar
+    targetRevision: HEAD
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/tube-archivist/archivist-deployment.yaml
+++ b/tube-archivist/archivist-deployment.yaml
@@ -1,0 +1,72 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: tubearchivist
+  namespace: tube-archivist
+  labels:
+    io.kompose.service: tubearchivist
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: tubearchivist
+  template:
+    metadata:
+      creationTimestamp: null
+      labels:
+        io.kompose.service: tubearchivist
+    spec:
+      volumes:
+        - name: media
+          hostPath:
+            path: /local/tube-archivist/media
+            type: ''
+        - name: cache
+          hostPath:
+            path: /local/tube-archivist/cache
+            type: ''
+      containers:
+        - name: tubearchivist
+          image: bbilly1/tubearchivist:v0.4.10
+          ports:
+            - containerPort: 8000
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: archivist-config
+          resources: {}
+          volumeMounts:
+            - name: media
+              mountPath: /youtube
+            - name: cache
+              mountPath: /cache
+          livenessProbe:
+            exec:
+              command:
+                - curl
+                - '-f'
+                - http://localhost:8000/health
+            initialDelaySeconds: 30
+            timeoutSeconds: 10
+            periodSeconds: 120
+            successThreshold: 1
+            failureThreshold: 3
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      nodeSelector:
+        kubernetes.io/hostname: k-w-3
+      securityContext: {}
+      schedulerName: default-scheduler
+      tolerations:
+        - key: local-storage-available
+          operator: Equal
+          value: 'true'
+          effect: NoSchedule
+  strategy:
+    type: Recreate
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600

--- a/tube-archivist/elasticsearch-deployment.yaml
+++ b/tube-archivist/elasticsearch-deployment.yaml
@@ -1,0 +1,54 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: archivist-es
+  namespace: tube-archivist
+  labels:
+    io.kompose.service: archivist-es
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: archivist-es
+  template:
+    metadata:
+      labels:
+        io.kompose.service: archivist-es
+    spec:
+      volumes:
+        - name: es
+          persistentVolumeClaim:
+            claimName: es-1
+      containers:
+        - name: archivist-es
+          image: bbilly1/tubearchivist-es
+          ports:
+            - containerPort: 9200
+              protocol: TCP
+          env:
+            - name: ELASTIC_PASSWORD
+              value: verysecret
+            - name: ES_JAVA_OPTS
+              value: '-Xms8g -Xmx8g'
+            - name: discovery.type
+              value: single-node
+            - name: path.repo
+              value: /usr/share/elasticsearch/data/snapshot
+            - name: xpack.security.enabled
+              value: 'true'
+          resources: {}
+          volumeMounts:
+            - name: es
+              mountPath: /usr/share/elasticsearch/data
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+  strategy:
+    type: Recreate
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600

--- a/tube-archivist/redis-deployment.yaml
+++ b/tube-archivist/redis-deployment.yaml
@@ -1,0 +1,43 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: archivist-redis
+  namespace: tube-archivist
+  labels:
+    io.kompose.service: archivist-redis
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: archivist-redis
+  template:
+    metadata:
+      labels:
+        io.kompose.service: archivist-redis
+    spec:
+      volumes:
+        - name: redis
+          persistentVolumeClaim:
+            claimName: redis-1
+      containers:
+        - name: archivist-redis
+          image: redis/redis-stack-server
+          ports:
+            - containerPort: 6379
+              protocol: TCP
+          resources: {}
+          volumeMounts:
+            - name: redis
+              mountPath: /data
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+  strategy:
+    type: Recreate
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600


### PR DESCRIPTION
This commit introduces the Tube Archivist application to our project. The application is defined in a new YAML file and includes specifications for its deployment, including automated sync policy and namespace creation.

Additionally, three new deployments have been added - one each for Elasticsearch, Redis, and the main Tube Archivist service. These deployments include configurations such as container images, ports, environment variables, volume mounts, and more.

The changes also specify node selectors and tolerations to ensure that the services are scheduled on appropriate nodes. Health checks have been set up for the main service to monitor its status regularly.

Lastly, persistent volumes have been configured for Elasticsearch and Redis to ensure data persistence across restarts or failures.
