### PR TITLE
:sparkles: Added Glance application and deployment

### DIFF
--- a/apps/glance.yaml
+++ b/apps/glance.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: glance
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+  source:
+    path: glance
+    repoURL: https://github.com/mizar-labs/mizar
+    targetRevision: HEAD
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/glance/deployment.yaml
+++ b/glance/deployment.yaml
@@ -1,0 +1,49 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: glance
+  namespace: glance
+  labels:
+    io.kompose.service: glance
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: glance
+  template:
+    metadata:
+      labels:
+        io.kompose.service: glance
+    spec:
+      volumes:
+        - name: glance-config
+          configMap:
+            name: glance
+            defaultMode: 420
+      containers:
+        - name: glance
+          image: glanceapp/glance:v0.5.1
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          env:
+            - name: TZ
+              value: America/Chicago
+          resources: {}
+          volumeMounts:
+            - name: glance-config
+              mountPath: /app/glance.yml
+              subPath: glance.yml
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+  strategy:
+    type: Recreate
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600


### PR DESCRIPTION
Introduced a new Application for ArgoCD named 'glance' in the 'argocd' namespace. The source code is fetched from a specific GitHub repository, with automated sync policy enabled for self-healing and pruning.

Also added a new Deployment configuration for the 'glance' service. This includes setting up environment variables, volumes, container specifications like image details, ports, etc., along with policies related to termination, restarts and scheduling.
