### PR TITLE
:sparkles: Added new Application and Deployment for free-games-claimer

### DIFF
--- a/apps/free-games-claimer.yaml
+++ b/apps/free-games-claimer.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: free-games-claimer
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+  source:
+    path: free-games-claimer
+    repoURL: https://github.com/mizar-labs/mizar
+    targetRevision: HEAD
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/free-games-claimer/deployment.yaml
+++ b/free-games-claimer/deployment.yaml
@@ -1,0 +1,50 @@
+kind: Deployment
+apiVersion: apps/v1
+metadata:
+  name: free-games-claimer
+  namespace: free-games-claimer
+  labels:
+    io.kompose.service: free-games-claimer
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      io.kompose.service: free-games-claimer
+  template:
+    metadata:
+      labels:
+        io.kompose.service: free-games-claimer
+    spec:
+      volumes:
+        - name: fgc
+          persistentVolumeClaim:
+            claimName: fgc
+      containers:
+        - name: fgc
+          image: ghcr.io/vogler/free-games-claimer
+          args:
+            - bash
+            - '-c'
+            - node prime-gaming; node gog
+          ports:
+            - containerPort: 6080
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: free-games-claimer-config
+          resources: {}
+          volumeMounts:
+            - name: fgc
+              mountPath: /fgc/data
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      securityContext: {}
+      schedulerName: default-scheduler
+  strategy:
+    type: Recreate
+  revisionHistoryLimit: 10
+  progressDeadlineSeconds: 600


### PR DESCRIPTION
This commit introduces a new ArgoCD Application and Kubernetes Deployment for the `free-games-claimer` service. The application is configured to automatically sync from the HEAD of the main repository, with pruning and self-healing enabled. The deployment sets up a container running the `free-games-claimer` image, with environment variables sourced from a secret. It also includes configuration for persistent storage, termination policies, and scheduling options.
