### PR TITLE
:sparkles: Added new Application and StatefulSet for open-webui

### DIFF
--- a/apps/open-webui.yaml
+++ b/apps/open-webui.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: open-webui
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+  source:
+    path: open-webui
+    repoURL: https://github.com/mizar-labs/mizar
+    targetRevision: HEAD
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/open-webui/statefulset.yaml
+++ b/open-webui/statefulset.yaml
@@ -1,0 +1,70 @@
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: open-webui
+  namespace: open-webui
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/component: open-webui
+      app.kubernetes.io/instance: open-webui
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/component: open-webui
+        app.kubernetes.io/instance: open-webui
+    spec:
+      volumes:
+        - name: data
+          persistentVolumeClaim:
+            claimName: open-webui
+      initContainers:
+        - name: copy-app-data
+          image: ghcr.io/open-webui/open-webui:latest
+          command:
+            - sh
+            - '-c'
+            - cp -R -n /app/backend/data/* /tmp/app-data/
+          resources: {}
+          volumeMounts:
+            - name: data
+              mountPath: /tmp/app-data
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+      containers:
+        - name: open-webui
+          image: ghcr.io/open-webui/open-webui:latest
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: open-webui-config
+          resources: {}
+          volumeMounts:
+            - name: data
+              mountPath: /app/backend/data
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+          tty: true
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 30
+      dnsPolicy: ClusterFirst
+      automountServiceAccountToken: false
+      securityContext: {}
+      schedulerName: default-scheduler
+      enableServiceLinks: false
+  serviceName: open-webui
+  podManagementPolicy: OrderedReady
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      partition: 0
+  revisionHistoryLimit: 10
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain


### PR DESCRIPTION
This commit introduces a new Application configuration for the open-webui project in ArgoCD. The application is set to automatically sync with the latest revision from its GitHub repository.

Additionally, a StatefulSet has been created for open-webui. This includes an initContainer to copy app data, and a main container running the latest version of open-webui. The StatefulSet also defines volume mounts, environment variables from secrets, and various other specifications like update strategy and persistent volume claim retention policy.
