### PR TITLE
WIP on open-webui

### DIFF
--- a/open-webui/pvc.yaml
+++ b/open-webui/pvc.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: open-webui
+  namespace: open-webui
+  labels:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/component: open-webui
+spec:
+  accessModes:
+    - "ReadWriteOnce"
+  resources:
+    requests:
+      storage: 20Gi
+  storageClassName: longhorn

--- a/open-webui/service-account.yaml
+++ b/open-webui/service-account.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: open-webui
+  namespace: open-webui
+  labels:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/component: open-webui
+automountServiceAccountToken: false

--- a/open-webui/service.yaml
+++ b/open-webui/service.yaml
@@ -1,0 +1,19 @@
+# Source: open-webui/templates/service.yaml
+apiVersion: v1
+kind: Service
+metadata:
+  name: open-webui
+  namespace: open-webui
+  labels:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/component: open-webui
+spec:
+  selector:
+    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/component: open-webui
+  type: ClusterIP
+  ports:
+    - protocol: TCP
+      name: http
+      port: 80
+      targetPort: http


### PR DESCRIPTION
:construction: WIP on open-webui

Added PersistentVolumeClaim, ServiceAccount, and Service for open-webui. The PersistentVolumeClaim is set to use the longhorn storage class with a request of 20Gi. The ServiceAccount has automountServiceAccountToken disabled. The Service is configured as a ClusterIP type with an HTTP port exposed at 80.
