### PR TITLE
:sparkles: Added new ConfigMap and patch in ArgoCD

### DIFF
--- a/argocd/config/argocd-cm.yaml
+++ b/argocd/config/argocd-cm.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+data:
+  resource.exclusions: |
+    - apiGroups:
+      - "cilium.io"
+      kinds:
+      - "CiliumIdentity"
+      clusters:
+      - "*"
+kind: ConfigMap
+metadata:
+  name: argocd-cm
+  namespace: argocd

--- a/argocd/kustomization.yaml
+++ b/argocd/kustomization.yaml
@@ -9,4 +9,9 @@ configMapGenerator:
     behavior: replace
     envs:
       - config/argocd-cmd-params-cm
+patches:
+  - path: config/argocd-cm.yaml
+    target:
+      kind: ConfigMap
+      name: argocd-cm
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
A new ConfigMap named 'argocd-cm' has been added to the ArgoCD configuration. This ConfigMap includes resource exclusions for a specific API group and kind. Additionally, a patch has been introduced in the kustomization file to target this newly created ConfigMap.
