### PR TITLE
:sparkles: Added IngressRoute and Certificate for open-webui

### DIFF
--- a/open-webui/ingress.yaml
+++ b/open-webui/ingress.yaml
@@ -1,0 +1,30 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: open-webui
+  namespace: open-webui
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`ai.mizar.scalar.cloud`)
+      priority: 10
+      services:
+        - name: open-webui
+          port: 80
+  tls:
+    secretName: open-webui-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: open-webui
+  namespace: open-webui
+spec:
+  secretName: open-webui-tls
+  dnsNames:
+    - "ai.mizar.scalar.cloud"
+  issuerRef:
+    name: le-staging
+    kind: ClusterIssuer


### PR DESCRIPTION
This commit introduces a new IngressRoute and Certificate for the 'open-webui' service. The IngressRoute is configured to match the host 'ai.mizar.scalar.cloud' with priority 10, and it points to the 'open-webui' service on port 80. TLS is enabled using a secret named 'open-webui-tls'. Additionally, a new Certificate has been created in the same namespace with DNS names set to "ai.mizar.scalar.cloud" issued by 'le-staging'.
