### PR TITLE
:label: Update Kubernetes labels and selectors

### DIFF
--- a/open-webui/service.yaml
+++ b/open-webui/service.yaml
@@ -5,11 +5,11 @@ metadata:
   name: open-webui
   namespace: open-webui
   labels:
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: open-webui
     app.kubernetes.io/component: open-webui
 spec:
   selector:
-    app.kubernetes.io/instance: release-name
+    app.kubernetes.io/instance: open-webui
     app.kubernetes.io/component: open-webui
   type: ClusterIP
   ports:


### PR DESCRIPTION
The commit updates the 'app.kubernetes.io/instance' label and selector in the service.yaml file from 'release-name' to 'open-webui'. This change aligns the instance name with the component, improving consistency across our Kubernetes configuration.
