### PR TITLE
:gear: Updated issuer reference in ingress configuration

### DIFF
--- a/epic-free-games/ingress.yaml
+++ b/epic-free-games/ingress.yaml
@@ -31,5 +31,5 @@ spec:
   dnsNames:
     - "epic.mizar.scalar.cloud"
   issuerRef:
-    name: le-staging
+    name: le-prod
     kind: ClusterIssuer


### PR DESCRIPTION
The issuer reference in the ingress.yaml file has been updated from 'le-staging' to 'le-prod'. This change is significant as it switches the environment context for the certificate issuer.
