### PR TITLE
:sparkles: Added Ingress and Service for free-games-claimer

### DIFF
--- a/free-games-claimer/ingress.yaml
+++ b/free-games-claimer/ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: free-games-claimer
+  namespace: free-games-claimer
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`fgc.mizar.scalar.cloud`)
+      middlewares:
+        - name: home-networks
+          namespace: default
+      priority: 10
+      services:
+        - name: free-games-claimer
+          kind: Service
+          namespace: free-games-claimer
+          port: http
+  tls:
+    secretName: free-games-claimer-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: free-games-claimer
+  namespace: free-games-claimer
+spec:
+  secretName: free-games-claimer-tls
+  dnsNames:
+    - "fgc.mizar.scalar.cloud"
+  issuerRef:
+    name: le-staging
+    kind: ClusterIssuer

--- a/free-games-claimer/service.yaml
+++ b/free-games-claimer/service.yaml
@@ -1,0 +1,19 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: free-games-claimer
+  namespace: free-games-claimer
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 6080
+      targetPort: 6080
+  selector:
+    io.kompose.service: free-games-claimer
+  type: ClusterIP
+  sessionAffinity: None
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
+  internalTrafficPolicy: Cluster


### PR DESCRIPTION
In this update, we've introduced an IngressRoute and a Service for the free-games-claimer. The IngressRoute is configured with specific entry points, routes, middlewares, services, and TLS settings. A Certificate has also been added to ensure secure communication.

The new Service is set up with specific ports, selectors, type of service, session affinity settings as well as IP family policies. This will help in managing network traffic within the cluster effectively.
