### PR TITLE
:arrow_up: Increased replica count in deployment

### DIFF
--- a/free-games-claimer/deployment.yaml
+++ b/free-games-claimer/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     io.kompose.service: free-games-claimer
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       io.kompose.service: free-games-claimer


### PR DESCRIPTION
The number of replicas for the service has been increased from 0 to 1. This change will ensure that there is always at least one instance of the service running, improving availability and reliability.
