### PR TITLE
:gear: Switched to production SSL certificate issuer

### DIFF
--- a/free-games-claimer/ingress.yaml
+++ b/free-games-claimer/ingress.yaml
@@ -31,5 +31,5 @@ spec:
   dnsNames:
     - "fgc.mizar.scalar.cloud"
   issuerRef:
-    name: le-staging
+    name: le-prod
     kind: ClusterIssuer


### PR DESCRIPTION
The SSL certificate issuer has been updated from the staging environment to the production environment in the ingress configuration. This change ensures that a valid and trusted SSL certificate is used for secure connections.
