### PR TITLE
:sparkles: Added Ingress and Service for FoundryVTT

### DIFF
--- a/foundryvtt/ingress.yaml
+++ b/foundryvtt/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: foundryvtt
+  namespace: foundry
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`foundry.mizar.scalar.cloud`)
+      priority: 10
+      services:
+        - name: foundry-foundry-vtt
+          kind: Service
+          namespace: foundry
+          port: http
+  tls:
+    secretName: foundryvtt-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: foundryvtt
+  namespace: foundry
+spec:
+  secretName: foundryvtt-tls
+  dnsNames:
+    - "foundry.mizar.scalar.cloud"
+  issuerRef:
+    name: le-staging
+    kind: ClusterIssuer

--- a/foundryvtt/service.yaml
+++ b/foundryvtt/service.yaml
@@ -1,0 +1,20 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: foundry-foundry-vtt
+  namespace: foundry
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+  selector:
+    app.kubernetes.io/instance: foundry
+    app.kubernetes.io/name: foundry-vtt
+  type: ClusterIP
+  sessionAffinity: None
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
+  internalTrafficPolicy: Cluster


### PR DESCRIPTION
Introduced new IngressRoute and Certificate configurations under the 'foundry' namespace. The IngressRoute is set to match a specific host with priority, and it's linked to a service on the HTTP port. The Certificate configuration includes DNS names and references a ClusterIssuer.

Also added a new Service configuration in the 'foundry' namespace. This service exposes an HTTP port, uses TCP protocol, and selects instances based on app labels. It's configured as ClusterIP type with no session affinity, IPv4 family policy, and cluster internal traffic policy.
