### PR TITLE
:gear: Updated issuer reference in ingress configuration

### DIFF
--- a/foundryvtt/ingress.yaml
+++ b/foundryvtt/ingress.yaml
@@ -28,5 +28,5 @@ spec:
   dnsNames:
     - "foundry.mizar.scalar.cloud"
   issuerRef:
-    name: le-staging
+    name: le-prod
     kind: ClusterIssuer


### PR DESCRIPTION
The issuer reference in the ingress configuration has been updated from 'le-staging' to 'le-prod'. This change is significant as it switches the environment context for certificate issuance.
