### PR TITLE
:sparkles: Added Ingress and Service for Glance

### DIFF
--- a/glance/ingress.yaml
+++ b/glance/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: glance
+  namespace: glance
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`glance.mizar.scalar.cloud`)
+      priority: 10
+      services:
+        - name: glance
+          kind: Service
+          namespace: glance
+          port: http
+  tls:
+    secretName: glance-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: glance
+  namespace: glance
+spec:
+  secretName: glance-tls
+  dnsNames:
+    - "glance.mizar.scalar.cloud"
+  issuerRef:
+    name: le-staging
+    kind: ClusterIssuer

--- a/glance/service.yaml
+++ b/glance/service.yaml
@@ -1,0 +1,19 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: glance
+  namespace: glance
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8080
+      targetPort: http
+  selector:
+    io.kompose.service: glance
+  type: ClusterIP
+  sessionAffinity: None
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
+  internalTrafficPolicy: Cluster


### PR DESCRIPTION
Introduced a new IngressRoute and Certificate for the Glance service in the 'glance' namespace. The IngressRoute is configured to match a specific host with priority, and it's linked to the Glance service on HTTP port. A TLS secret is also specified.

Additionally, created a new Service for Glance in the 'glance' namespace. This service exposes an HTTP port and uses TCP protocol. It selects pods based on certain labels, has no session affinity, supports only IPv4 traffic, and allows cluster-wide internal traffic.
