### PR TITLE
:gear: Update SSL certificate issuer

### DIFF
--- a/glance/ingress.yaml
+++ b/glance/ingress.yaml
@@ -28,5 +28,5 @@ spec:
   dnsNames:
     - "glance.mizar.scalar.cloud"
   issuerRef:
-    name: le-staging
+    name: le-prod
     kind: ClusterIssuer


### PR DESCRIPTION
The SSL certificate issuer for the ingress resource has been updated. Previously, it was using the staging environment's issuer. Now, it uses the production environment's issuer.
