### PR TITLE
:sparkles: Added Ingress and Service for Octobot

### DIFF
--- a/octobot/ingress.yaml
+++ b/octobot/ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: octobot
+  namespace: octobot
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`octobot.mizar.scalar.cloud`)
+      middlewares:
+        - name: ak-outpost-authentik-embedded-outpost
+          namespace: authentik
+      priority: 10
+      services:
+        - name: octobot
+          kind: Service
+          namespace: octobot
+          port: http
+  tls:
+    secretName: octobot-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: octobot
+  namespace: octobot
+spec:
+  secretName: octobot-tls
+  dnsNames:
+    - "octobot.mizar.scalar.cloud"
+  issuerRef:
+    name: le-prod
+    kind: ClusterIssuer

--- a/octobot/service.yaml
+++ b/octobot/service.yaml
@@ -1,0 +1,19 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: octobot
+  namespace: octobot
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 5001
+  selector:
+    io.kompose.service: octobot
+  type: ClusterIP
+  sessionAffinity: None
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
+  internalTrafficPolicy: Cluster


### PR DESCRIPTION
Introduced new IngressRoute and Certificate configurations in the ingress.yaml file. The IngressRoute is set to match a specific host with priority, includes middleware, and points to a service within the same namespace. The Certificate configuration specifies a secretName, dnsNames, and an issuerRef.

Also added a new Service configuration in the service.yaml file. This service exposes port 80 (targeting port 5001) as ClusterIP type with no session affinity. It also defines IP family policy and internal traffic policy settings.
