### PR TITLE
:sparkles: Added Ingress and Service for Tube Archivist

### DIFF
--- a/tube-archivist/ingress.yaml
+++ b/tube-archivist/ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: tube-archivist
+  namespace: tube-archivist
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`tube.mizar.scalar.cloud`)
+      middlewares:
+        - name: ak-outpost-authentik-embedded-outpost
+          namespace: authentik
+      priority: 10
+      services:
+        - name: tubearchivist
+          kind: Service
+          namespace: tube-archivist
+          port: http
+  tls:
+    secretName: tube-archivist-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: tube-archivist
+  namespace: tube-archivist
+spec:
+  secretName: tube-archivist-tls
+  dnsNames:
+    - "tube.mizar.scalar.cloud"
+  issuerRef:
+    name: le-staging
+    kind: ClusterIssuer

--- a/tube-archivist/service.yaml
+++ b/tube-archivist/service.yaml
@@ -1,0 +1,19 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: tubearchivist
+  namespace: tube-archivist
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 8000
+      targetPort: 8000
+  selector:
+    io.kompose.service: tubearchivist
+  type: ClusterIP
+  sessionAffinity: None
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
+  internalTrafficPolicy: Cluster


### PR DESCRIPTION
In this update, we've introduced an IngressRoute and a Certificate for the tube-archivist application. The IngressRoute is configured with specific entry points, routes, middlewares, services, and TLS settings. The Certificate includes DNS names and issuer reference.

Additionally, a new Service has been created for tube-archivist. This service is set up with specific ports, selectors, type of service, session affinity policy as well as IP family policies.
