### PR TITLE
:gear: Update issuer reference in ingress configuration

### DIFF
--- a/tube-archivist/ingress.yaml
+++ b/tube-archivist/ingress.yaml
@@ -31,5 +31,5 @@ spec:
   dnsNames:
     - "tube.mizar.scalar.cloud"
   issuerRef:
-    name: le-staging
+    name: le-prod
     kind: ClusterIssuer


### PR DESCRIPTION
The issuer reference in the ingress.yaml file has been updated from 'le-staging' to 'le-prod'. This change is significant as it switches the environment context for certificate issuance.
