### PR TITLE
:sparkles: Added Ingress and Service for Ollama

### DIFF
--- a/ollama/ingress.yaml
+++ b/ollama/ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: ollama
+  namespace: ollama
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`ollama.mizar.scalar.cloud`)
+      middlewares:
+        - name: home-networks
+          namespace: default
+      priority: 10
+      services:
+        - name: ollama
+          kind: Service
+          namespace: ollama
+          port: http
+  tls:
+    secretName: ollama-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: ollama
+  namespace: ollama
+spec:
+  secretName: ollama-tls
+  dnsNames:
+    - "ollama.mizar.scalar.cloud"
+  issuerRef:
+    name: le-prod
+    kind: ClusterIssuer

--- a/ollama/service.yaml
+++ b/ollama/service.yaml
@@ -1,0 +1,19 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: ollama
+  namespace: ollama
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: http
+  selector:
+    name: ollama
+  type: ClusterIP
+  sessionAffinity: None
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
+  internalTrafficPolicy: Cluster


### PR DESCRIPTION
Introduced a new IngressRoute and Certificate in the ollama namespace, configured to use websecure entry point with home-networks middleware. The route matches a specific host and directs traffic to the newly created ollama service on port http.

Also added a new ClusterIP type Service in the ollama namespace. This service listens on port 80 (http) and routes traffic to targets labeled with 'ollama'. It's configured for IPv4 only and allows cluster-wide internal traffic.
