### PR TITLE
:lock: Updated TLS secret name

### DIFF
--- a/ollama/ingress.yaml
+++ b/ollama/ingress.yaml
@@ -19,7 +19,7 @@ spec:
           namespace: ollama
           port: http
   tls:
-    secretName: ollama-tls
+    secretName: ollama-api-tls
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -27,7 +27,7 @@ metadata:
   name: ollama
   namespace: ollama
 spec:
-  secretName: ollama-tls
+  secretName: ollama-api-tls
   dnsNames:
     - "ollama.mizar.scalar.cloud"
   issuerRef:


### PR DESCRIPTION
The TLS secret name in the ingress and certificate specifications has been updated. The previous name was replaced with a more specific one to better reflect its purpose. This change enhances clarity and maintainability of the codebase.
