### PR TITLE
:gear: Update Grafana ingress issuer reference

### DIFF
--- a/monitoring/grafana-ingress.yaml
+++ b/monitoring/grafana-ingress.yaml
@@ -28,5 +28,5 @@ spec:
   dnsNames:
     - "grafana.mizar.scalar.cloud"
   issuerRef:
-    name: le-staging
+    name: le-prod
     kind: ClusterIssuer


### PR DESCRIPTION
The issuer reference in the Grafana ingress configuration has been updated from staging to production. This change ensures that the correct certificate issuer is used for the production environment.
