### PR TITLE
:rocket: Added ArgoCD Application and IngressRoute

### DIFF
--- a/apps/kube-system.yaml
+++ b/apps/kube-system.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kube-system
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+  source:
+    path: kube-system
+    repoURL: https://github.com/mizar-labs/mizar
+    targetRevision: HEAD
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/kube-system/ingress.yaml
+++ b/kube-system/ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: hubble
+  namespace: kube-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`hubble.mizar.scalar.cloud`)
+      middlewares:
+        - name: ak-outpost-authentik-embedded-outpost
+          namespace: authentik
+      priority: 10
+      services:
+        - name: hubble-ui
+          kind: Service
+          namespace: kube-system
+          port: http
+  tls:
+    secretName: hubble-ui-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: hubble-ui
+  namespace: kube-system
+spec:
+  secretName: hubble-ui-tls
+  dnsNames:
+    - "hubble.mizar.scalar.cloud"
+  issuerRef:
+    name: le-staging
+    kind: ClusterIssuer


### PR DESCRIPTION
Added a new ArgoCD Application for the kube-system namespace. The application is configured to sync from a specific GitHub repository, with automated pruning and self-healing enabled.

Also added an IngressRoute for the hubble service in the kube-system namespace. This includes a rule matching a specific host, middleware reference, and associated service details. A Certificate resource has also been defined for TLS encryption using cert-manager.
