### PR TITLE
:gear: Update issuer reference in ingress configuration

### DIFF
--- a/kube-system/ingress.yaml
+++ b/kube-system/ingress.yaml
@@ -31,5 +31,5 @@ spec:
   dnsNames:
     - "hubble.mizar.scalar.cloud"
   issuerRef:
-    name: le-staging
+    name: le-prod
     kind: ClusterIssuer


### PR DESCRIPTION
The issuer reference in the ingress configuration has been updated. Previously, it was pointing to a staging environment. Now, it's set to point to the production environment. This change ensures that our Kubernetes system uses the correct certificate issuer for its Ingress resources.
