### PR TITLE
:sparkles: Added Longhorn system and ingress configurations

### DIFF
--- a/apps/longhorn-system.yaml
+++ b/apps/longhorn-system.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: longhorn-system
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+  source:
+    path: longhorn-system
+    repoURL: https://github.com/mizar-labs/mizar
+    targetRevision: HEAD
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/longhorn-system/ingress.yaml
+++ b/longhorn-system/ingress.yaml
@@ -1,0 +1,35 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: longhorn-frontend
+  namespace: longhorn-system
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`longhorn.mizar.scalar.cloud`)
+      middlewares:
+        - name: ak-outpost-authentik-embedded-outpost
+          namespace: authentik
+      priority: 10
+      services:
+        - name: longhorn-frontend
+          kind: Service
+          namespace: longhorn-system
+          port: http
+  tls:
+    secretName: longhorn-frontend-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: longhorn-frontend
+  namespace: longhorn-system
+spec:
+  secretName: longhorn-frontend-tls
+  dnsNames:
+    - "longhorn.mizar.scalar.cloud"
+  issuerRef:
+    name: le-staging
+    kind: ClusterIssuer


### PR DESCRIPTION
The commit introduces two new configuration files for the Longhorn system. The first file sets up an ArgoCD Application for the Longhorn system, specifying its source repository, target revision, and sync policy. It also enables automated syncing with pruning and self-healing options.

The second file defines an IngressRoute and a Certificate for the Longhorn frontend in the longhorn-system namespace. The IngressRoute specifies entry points, routing rules, middlewares, services, and TLS settings. The Certificate is configured to use a ClusterIssuer to issue certificates for specified DNS names.
