### PR TITLE
:gear: Updated issuer reference in ingress configuration

### DIFF
--- a/longhorn-system/ingress.yaml
+++ b/longhorn-system/ingress.yaml
@@ -31,5 +31,5 @@ spec:
   dnsNames:
     - "longhorn.mizar.scalar.cloud"
   issuerRef:
-    name: le-staging
+    name: le-prod
     kind: ClusterIssuer


### PR DESCRIPTION
The issuer reference in the ingress.yaml file has been updated. The previous staging environment reference has been replaced with a production environment reference. This change is crucial for the deployment process as it directs traffic to the correct environment.
