### PR TITLE
:sparkles: Added Plex application to ArgoCD

### DIFF
--- a/apps/plex.yaml
+++ b/apps/plex.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: plex
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+  source:
+    path: plex
+    repoURL: https://github.com/mizar-labs/mizar
+    targetRevision: HEAD
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/plex/ingress.yaml
+++ b/plex/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: plex
+  namespace: plex
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`plex.mizar.scalar.cloud`)
+      priority: 10
+      services:
+        - name: plex-plex-media-server
+          kind: Service
+          namespace: plex
+          port: pms
+  tls:
+    secretName: plex-pms-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: foundryvtt
+  namespace: plex
+spec:
+  secretName: plex-pms-tls
+  dnsNames:
+    - "plex.mizar.scalar.cloud"
+  issuerRef:
+    name: le-staging
+    kind: ClusterIssuer

--- a/plex/service.yaml
+++ b/plex/service.yaml
@@ -1,0 +1,20 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: plex-plex-media-server
+  namespace: plex
+spec:
+  ports:
+    - name: pms
+      protocol: TCP
+      port: 32400
+      targetPort: 32400
+  selector:
+    app.kubernetes.io/instance: plex
+    app.kubernetes.io/name: plex-media-server
+  type: ClusterIP
+  sessionAffinity: None
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
+  internalTrafficPolicy: Cluster

--- a/plex/statefulset.yaml
+++ b/plex/statefulset.yaml
@@ -1,0 +1,72 @@
+kind: StatefulSet
+apiVersion: apps/v1
+metadata:
+  name: plex-plex-media-server
+  namespace: plex
+spec:
+  replicas: 0
+  selector:
+    matchLabels:
+      app.kubernetes.io/instance: plex
+      app.kubernetes.io/name: plex-media-server
+  template:
+    metadata:
+      labels:
+        app: plex-media-server
+        app.kubernetes.io/instance: plex
+        app.kubernetes.io/name: plex-media-server
+    spec:
+      volumes:
+        - name: pms-config
+          persistentVolumeClaim:
+            claimName: config
+        - name: pms-transcode
+          emptyDir: {}
+        - name: media
+          persistentVolumeClaim:
+            claimName: media
+      containers:
+        - name: plex-plex-media-server-pms
+          image: index.docker.io/plexinc/pms-docker:latest
+          ports:
+            - name: pms
+              containerPort: 32400
+              protocol: TCP
+          envFrom:
+            - secretRef:
+                name: plex-config
+          resources: {}
+          volumeMounts:
+            - name: pms-config
+              mountPath: /config
+            - name: pms-transcode
+              mountPath: /transcode
+            - name: media
+              mountPath: /data
+          terminationMessagePath: /dev/termination-log
+          terminationMessagePolicy: File
+          imagePullPolicy: IfNotPresent
+      restartPolicy: Always
+      terminationGracePeriodSeconds: 120
+      dnsPolicy: ClusterFirst
+      serviceAccountName: plex-plex-media-server
+      serviceAccount: plex-plex-media-server
+      securityContext: {}
+      affinity: {}
+      schedulerName: default-scheduler
+      tolerations:
+        - key: local-storage-available
+          operator: Equal
+          value: 'true'
+          effect: NoSchedule
+      runtimeClassName: nvidia
+  serviceName: plex-plex-media-server
+  podManagementPolicy: OrderedReady
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      partition: 0
+  revisionHistoryLimit: 10
+  persistentVolumeClaimRetentionPolicy:
+    whenDeleted: Retain
+    whenScaled: Retain


### PR DESCRIPTION
This commit introduces the Plex media server application into our ArgoCD setup. The new files include a definition for the Plex application in ArgoCD, an IngressRoute for Traefik, a Service and StatefulSet for Kubernetes, and a Certificate for cert-manager. The configuration includes automated sync policy with pruning and self-healing enabled. The service is set up as a ClusterIP type with TCP protocol on port 32400. The statefulset uses the latest plexinc/pms-docker image from Docker Hub and has been configured with persistent volume claims for config and media data, as well as an emptyDir volume for transcoding data.
