### PR TITLE
🔁 Updated certificate details in ingress configuration

### DIFF
--- a/plex/ingress.yaml
+++ b/plex/ingress.yaml
@@ -21,12 +21,12 @@ spec:
 apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
-  name: foundryvtt
+  name: plex
   namespace: plex
 spec:
   secretName: plex-pms-tls
   dnsNames:
     - "plex.mizar.scalar.cloud"
   issuerRef:
-    name: le-staging
+    name: le-prod
     kind: ClusterIssuer


### PR DESCRIPTION
The commit includes changes to the ingress.yaml file. The name of the Certificate under metadata has been updated from 'foundryvtt' to 'plex'. Also, the issuerRef name has been changed from 'le-staging' to 'le-prod'. These modifications ensure that the correct certificate and issuer are being used for secure connections.
