### PR TITLE
:arrow_up: Increased replica count in statefulset

### DIFF
--- a/plex/statefulset.yaml
+++ b/plex/statefulset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: plex-plex-media-server
   namespace: plex
 spec:
-  replicas: 0
+  replicas: 1
   selector:
     matchLabels:
       app.kubernetes.io/instance: plex


### PR DESCRIPTION
The number of replicas for the statefulset has been increased from 0 to 1. This change will ensure that there is always at least one instance running, improving the reliability and availability of the service.
