### PR TITLE
:recycle: Updated serviceAccountName in statefulset

### DIFF
--- a/plex/statefulset.yaml
+++ b/plex/statefulset.yaml
@@ -49,8 +49,7 @@ spec:
       restartPolicy: Always
       terminationGracePeriodSeconds: 120
       dnsPolicy: ClusterFirst
-      serviceAccountName: plex-plex-media-server
-      serviceAccount: plex-plex-media-server
+      serviceAccountName: default
       securityContext: {}
       affinity: {}
       schedulerName: default-scheduler


### PR DESCRIPTION
The serviceAccountName for the statefulset has been updated from 'plex-plex-media-server' to 'default'. This change simplifies the configuration and aligns with best practices for default account usage.
