### PR TITLE
:twisted_rightwards_arrows: Adjusted replica count in statefulset

### DIFF
--- a/plex/statefulset.yaml
+++ b/plex/statefulset.yaml
@@ -4,7 +4,7 @@ metadata:
   name: plex-plex-media-server
   namespace: plex
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app.kubernetes.io/instance: plex


### PR DESCRIPTION
The number of replicas for the statefulset has been reduced from 1 to 0. This change will affect the deployment strategy and resource allocation within the Kubernetes cluster.
