### PR TITLE
:sparkles: Added Authentik Application and IngressRoute

### DIFF
--- a/apps/authentik.yaml
+++ b/apps/authentik.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: authentik
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+  source:
+    path: authentik
+    repoURL: https://github.com/mizar-labs/mizar
+    targetRevision: HEAD
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/authentik/ingress.yaml
+++ b/authentik/ingress.yaml
@@ -1,0 +1,32 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: authentik-server
+  namespace: authentik
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`authentik.mizar.scalar.cloud`)
+      priority: 10
+      services:
+        - name: authentik-server
+          kind: Service
+          namespace: authentik
+          port: http
+  tls:
+    secretName: authentik-server-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: authentik-server
+  namespace: authentik
+spec:
+  secretName: authentik-server-tls
+  dnsNames:
+    - "authentik.mizar.scalar.cloud"
+  issuerRef:
+    name: le-staging
+    kind: ClusterIssuer

--- a/authentik/service.yaml
+++ b/authentik/service.yaml
@@ -1,0 +1,25 @@
+kind: Service
+apiVersion: v1
+metadata:
+  name: authentik-server
+  namespace: authentik
+spec:
+  ports:
+    - name: http
+      protocol: TCP
+      port: 80
+      targetPort: 9000
+    - name: https
+      protocol: TCP
+      port: 443
+      targetPort: 9443
+  selector:
+    app.kubernetes.io/component: server
+    app.kubernetes.io/instance: authentik
+    app.kubernetes.io/name: authentik
+  type: ClusterIP
+  sessionAffinity: None
+  ipFamilies:
+    - IPv4
+  ipFamilyPolicy: SingleStack
+  internalTrafficPolicy: Cluster


### PR DESCRIPTION
Introduced a new application configuration for Authentik in the ArgoCD namespace. The application is set to sync from a specific GitHub repository with automated pruning and self-healing enabled.

Also added an IngressRoute for the Authentik server in the authentik namespace, configured with websecure entry point and TLS certificate details.

Lastly, created a new service for the Authentik server within the authentik namespace, defining both HTTP and HTTPS ports along with their target ports.
