### PR TITLE
:gear: Switched issuer from staging to production

### DIFF
--- a/authentik/ingress.yaml
+++ b/authentik/ingress.yaml
@@ -28,5 +28,5 @@ spec:
   dnsNames:
     - "authentik.mizar.scalar.cloud"
   issuerRef:
-    name: le-staging
+    name: le-prod
     kind: ClusterIssuer


### PR DESCRIPTION
The issuer reference in the ingress configuration has been updated. Previously, it was set to use the 'le-staging' issuer. Now, it's configured to use the 'le-prod' issuer for a more stable and reliable environment.
