### PR TITLE
:gear: Updated ingress rules in YAML

### DIFF
--- a/tube-archivist/ingress.yaml
+++ b/tube-archivist/ingress.yaml
@@ -10,9 +10,8 @@ spec:
     - kind: Rule
       match: Host(`tube.mizar.scalar.cloud`)
       middlewares:
-        - name: ak-outpost-authentik-embedded-outpost
-          namespace: authentik
-      priority: 10
+        - name: home-networks
+          namespace: default
       services:
         - name: tubearchivist
           kind: Service


### PR DESCRIPTION
The ingress rules have been updated. The middleware reference has been changed from 'ak-outpost-authentik-embedded-outpost' to 'home-networks', and the namespace has also been switched from 'authentik' to 'default'.
