### PR TITLE
:gear: Enhanced network policy configuration

### DIFF
--- a/apps/authentik.yaml
+++ b/apps/authentik.yaml
@@ -31,8 +31,12 @@ spec:
           enabled: true
           auth:
             existingSecret: postgresql-config
+          networkPolicy:
+            enabled: false
         redis:
           enabled: true
+          networkPolicy:
+            enabled: false
   sources: []
   project: default
   syncPolicy:


### PR DESCRIPTION
The commit introduces a new feature that allows users to enable or disable the network policy for both PostgreSQL and Redis. This provides more flexibility in managing network access rules, improving security and control over data flow.
