### PR TITLE
:twisted_rightwards_arrows: Refactor network policy configuration

### DIFF
--- a/apps/authentik.yaml
+++ b/apps/authentik.yaml
@@ -31,8 +31,16 @@ spec:
           enabled: true
           auth:
             existingSecret: postgresql-config
-          networkPolicy:
-            enabled: false
+          primary:
+            networkPolicy:
+              enabled: false
+          readReplicas:
+            networkPolicy:
+              enabled: false
+          backup:
+            cronjob:
+              networkPolicy:
+                enabled: false
         redis:
           enabled: true
           networkPolicy:


### PR DESCRIPTION
The network policy configuration has been refactored to include primary, readReplicas, and backup sections. The existing networkPolicy setting is now nested under these new sections. This change allows for more granular control over the network policies of different components.
