### PR TITLE
:lock: Added TLS configuration to ingress

### DIFF
--- a/apps/authentik.yaml
+++ b/apps/authentik.yaml
@@ -25,6 +25,10 @@ spec:
             # Specify kubernetes ingress controller class name
             ingressClassName: traefik
             enabled: true
+            tls:
+              secretName: authentik-ingress-tls
+              hosts:
+                - authentik.mizar.scalar.cloud
             hosts:
                 - authentik.mizar.scalar.cloud
         postgresql:


### PR DESCRIPTION
The commit introduces a new TLS configuration for the ingress in the authentik application. This includes specifying a secret name and hosts under the tls section. The change enhances security by enabling encrypted communication.
