### PR TITLE
:twisted_rightwards_arrows: Reordered TLS configuration in authentik.yaml

### DIFF
--- a/apps/authentik.yaml
+++ b/apps/authentik.yaml
@@ -26,9 +26,9 @@ spec:
             ingressClassName: traefik
             enabled: true
             tls:
-              secretName: authentik-ingress-tls
-              hosts:
+            - hosts:
                 - authentik.mizar.scalar.cloud
+              secretName: authentik-ingress-tls
             hosts:
                 - authentik.mizar.scalar.cloud
         postgresql:


### PR DESCRIPTION
The TLS configuration block in the authentik application's YAML file has been rearranged. The 'secretName' and 'hosts' properties have been swapped to improve readability and maintain consistency with other similar configurations.
