### PR TITLE
:lock: Updated SSL certificate issuer

### DIFF
--- a/apps/authentik.yaml
+++ b/apps/authentik.yaml
@@ -21,8 +21,7 @@ spec:
           ingress:
             annotations:
               traefik.ingress.kubernetes.io/router.entrypoints: websecure
-              cert-manager.io/cluster-issuer: le-staging
-            # Specify kubernetes ingress controller class name
+              cert-manager.io/cluster-issuer: le-prod
             ingressClassName: traefik
             enabled: true
             tls:


### PR DESCRIPTION
The SSL certificate issuer has been updated from the staging environment to the production environment. This change ensures that the application uses a valid and trusted SSL certificate in production.
