### PR TITLE
:gear: Updated deployment and ingress configurations

### DIFF
--- a/free-games-claimer/deployment.yaml
+++ b/free-games-claimer/deployment.yaml
@@ -48,3 +48,4 @@ spec:
     type: Recreate
   revisionHistoryLimit: 10
   progressDeadlineSeconds: 600
+

--- a/tube-archivist/ingress.yaml
+++ b/tube-archivist/ingress.yaml
@@ -10,7 +10,7 @@ spec:
     - kind: Rule
       match: Host(`tube.mizar.scalar.cloud`)
       middlewares:
-        - name: home-networks
+        - name: authentik-auth-proxy
           namespace: default
       services:
         - name: tubearchivist


### PR DESCRIPTION
The deployment configuration has been updated to include a newline at the end of the file. In the ingress configuration, the middleware name has been changed from 'home-networks' to 'authentik-auth-proxy'.
