### PR TITLE
:gear: Updated Ingress Middleware

### DIFF
--- a/kube-system/ingress.yaml
+++ b/kube-system/ingress.yaml
@@ -10,8 +10,8 @@ spec:
     - kind: Rule
       match: Host(`hubble.mizar.scalar.cloud`)
       middlewares:
-        - name: ak-outpost-authentik-embedded-outpost
-          namespace: authentik
+        - name: authentik-auth-proxy
+          namespace: default
       priority: 10
       services:
         - name: hubble-ui


### PR DESCRIPTION
The middleware for the ingress rule in the kube-system has been updated. The name and namespace of the middleware have been changed to 'authentik-auth-proxy' and 'default', respectively, from their previous values.
