### PR TITLE
:lock: Updated authentication middleware in ingress configurations

### DIFF
--- a/longhorn-system/ingress.yaml
+++ b/longhorn-system/ingress.yaml
@@ -10,8 +10,8 @@ spec:
     - kind: Rule
       match: Host(`longhorn.mizar.scalar.cloud`)
       middlewares:
-        - name: ak-outpost-authentik-embedded-outpost
-          namespace: authentik
+        - name: authentik-auth-proxy
+          namespace: default
       priority: 10
       services:
         - name: longhorn-frontend

--- a/open-webui/ingress.yaml
+++ b/open-webui/ingress.yaml
@@ -10,8 +10,8 @@ spec:
     - kind: Rule
       match: Host(`ai.mizar.scalar.cloud`)
       middlewares:
-        - name: ak-outpost-authentik-embedded-outpost
-          namespace: authentik
+        - name: authentik-auth-proxy
+          namespace: default
       priority: 10
       services:
         - name: open-webui


### PR DESCRIPTION
The commit modifies the middleware used for authentication in both longhorn-system and open-webui ingress configurations. The previous 'ak-outpost-authentik-embedded-outpost' from 'authentik' namespace has been replaced with 'authentik-auth-proxy' from the 'default' namespace.
