### PR TITLE
:card_file_box: Switched from PersistentVolumeClaim to ConfigMap

### DIFF
--- a/apps/authentik.yaml
+++ b/apps/authentik.yaml
@@ -19,9 +19,9 @@ spec:
                 name: authentik-global-config
         server:
           volumes:
-            - name: authentik
-              persistentVolumeClaim:
-                claimName: authentik-custom-web
+            - name: authentik-custom-web
+              configMap:
+                name: authentik-custom-web
           volumeMounts:
             - name: authentik-custom-web
               mountPath: /custom-web


### PR DESCRIPTION
The volume configuration for the server in the authentik application has been updated. Instead of using a PersistentVolumeClaim named 'authentik', we're now using a ConfigMap named 'authentik-custom-web'. This change should improve flexibility and ease of configuration management.
