### PR TITLE
:gear: Update mountPath in authentik.yaml

### DIFF
--- a/apps/authentik.yaml
+++ b/apps/authentik.yaml
@@ -24,7 +24,7 @@ spec:
                 name: authentik-custom-web
           volumeMounts:
             - name: authentik-custom-web
-              mountPath: /custom-web
+              mountPath: /media/public/custom-web
           ingress:
             annotations:
               traefik.ingress.kubernetes.io/router.entrypoints: websecure


### PR DESCRIPTION
The mountPath for the 'authentik-custom-web' volume has been updated. It's now pointing to '/media/public/custom-web' instead of '/custom-web'. This change ensures that the correct directory is mounted for the application.
