### PR TITLE
:sparkles: Added custom logo support in authentik

### DIFF
--- a/apps/authentik.yaml
+++ b/apps/authentik.yaml
@@ -22,9 +22,14 @@ spec:
             - name: authentik-custom-web
               configMap:
                 name: authentik-custom-web
+           - name: authentik-custom-logo
+              configMap:
+                name: authentik-custom-logo
           volumeMounts:
             - name: authentik-custom-web
               mountPath: /media/public/custom-web
+            - name: authentik-custom-logo
+              mountPath: /media/public/custom-logo
           ingress:
             annotations:
               traefik.ingress.kubernetes.io/router.entrypoints: websecure


### PR DESCRIPTION
The commit introduces a new feature that allows users to add their own custom logos. This is achieved by creating a new volume and mount path for the custom logo in the authentik configuration file. The changes ensure that the custom logo can be accessed and displayed correctly.
