### PR TITLE
:art: Fixed indentation in authentik.yaml

### DIFF
--- a/apps/authentik.yaml
+++ b/apps/authentik.yaml
@@ -22,7 +22,7 @@ spec:
             - name: authentik-custom-web
               configMap:
                 name: authentik-custom-web
-           - name: authentik-custom-logo
+            - name: authentik-custom-logo
               configMap:
                 name: authentik-custom-logo
           volumeMounts:


### PR DESCRIPTION
The commit corrects the indentation for the 'authentik-custom-logo' configMap reference in the authentik.yaml file. This change ensures proper alignment with other elements, improving readability and maintaining consistency throughout the codebase.
