### PR TITLE
:sparkles: Added PersistentVolumeClaim for free-games-claimer

### DIFF
--- a/free-games-claimer-ronin/pvc.yaml
+++ b/free-games-claimer-ronin/pvc.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: fgc
+  name: fgc
+  namespace: free-games-claimer-ronin
+spec:
+  storageClassName: longhorn
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi


### PR DESCRIPTION
A new PersistentVolumeClaim (PVC) has been added to the free-games-claimer service. This PVC is configured with a storage class of 'longhorn' and an access mode of 'ReadWriteOnce'. It requests 10Gi of storage.
