### PR TITLE
:arrow_down: Decreased replica count to zero

### DIFF
--- a/free-games-claimer-ronin/deployment.yaml
+++ b/free-games-claimer-ronin/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     io.kompose.service: free-games-claimer
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       io.kompose.service: free-games-claimer

--- a/free-games-claimer/deployment.yaml
+++ b/free-games-claimer/deployment.yaml
@@ -6,7 +6,7 @@ metadata:
   labels:
     io.kompose.service: free-games-claimer
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       io.kompose.service: free-games-claimer


### PR DESCRIPTION
The number of replicas for the free-games-claimer service has been reduced from 1 to 0 in both ronin and main deployment configurations. This change will halt the running instances of this service.
