### PR TITLE
:arrow_up: Updated Foundry version

### DIFF
--- a/foundryvtt/deployment.yaml
+++ b/foundryvtt/deployment.yaml
@@ -79,7 +79,7 @@ spec:
             - name: FOUNDRY_PROXY_SSL
               value: 'true'
             - name: FOUNDRY_VERSION
-              value: '11.315'
+              value: '12.324'
             - name: FOUNDRY_AWS_CONFIG
               value: /etc/secretaws/awsConfig.json
             - name: FOUNDRY_COMPRESS_WEBSOCKET


### PR DESCRIPTION
The Foundry version in the deployment configuration has been updated. The previous value was '11.315', and it's now set to '12.324'. This change will ensure that we're using the latest stable release of Foundry for our deployments.
