### PR TITLE
:arrow_up: Updated FoundryVTT version

### DIFF
--- a/foundryvtt/deployment.yaml
+++ b/foundryvtt/deployment.yaml
@@ -79,7 +79,7 @@ spec:
             - name: FOUNDRY_PROXY_SSL
               value: 'true'
             - name: FOUNDRY_VERSION
-              value: '12.324'
+              value: '12.331'
             - name: FOUNDRY_AWS_CONFIG
               value: /etc/secretaws/awsConfig.json
             - name: FOUNDRY_COMPRESS_WEBSOCKET


### PR DESCRIPTION
The FoundryVTT version has been updated in the deployment configuration. The previous version was '12.324' and it has now been changed to '12.331'. This update should bring new features and improvements from the latest release.
