### PR TITLE
:sparkles: Added new Kubernetes configurations

### DIFF
--- a/apps/searxng.yaml
+++ b/apps/searxng.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: searxng
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+  source:
+    path: searxng
+    repoURL: https://github.com/mizar-labs/mizar
+    targetRevision: HEAD
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/searxng/redis-deployment.yaml
+++ b/searxng/redis-deployment.yaml
@@ -1,0 +1,48 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.kompose.service: redis
+  name: redis
+  namespace: searxng
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: redis
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        io.kompose.service: redis
+    spec:
+      containers:
+        - args:
+            - valkey-server
+            - --save
+            - "30"
+            - "1"
+            - --loglevel
+            - warning
+          image: docker.io/valkey/valkey:8-alpine
+          name: redis
+          ports:
+            - containerPort: 6739
+              protocol: TCP
+          securityContext:
+            capabilities:
+              add:
+                - SETGID
+                - SETUID
+                - DAC_OVERRIDE
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /data
+              name: valkey-data2
+      restartPolicy: Always
+      volumes:
+        - name: valkey-data2
+          persistentVolumeClaim:
+            claimName: valkey-data2

--- a/searxng/redis-service.yaml
+++ b/searxng/redis-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    io.kompose.service: redis
+  name: redis
+  namespace: searxng
+spec:
+  ports:
+    - name: redis
+      port: 6739
+      targetPort: 6739
+  selector:
+    io.kompose.service: redis

--- a/searxng/searxng-claim0-persistentvolumeclaim.yaml
+++ b/searxng/searxng-claim0-persistentvolumeclaim.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: searxng-claim0
+  name: searxng-claim0
+  namespace: searxng
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100G

--- a/searxng/searxng-deployment.yaml
+++ b/searxng/searxng-deployment.yaml
@@ -1,0 +1,49 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    io.kompose.service: searxng
+  name: searxng
+  namespace: searxng
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: searxng
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        io.kompose.service: searxng
+    spec:
+      containers:
+        - env:
+            - name: SEARXNG_BASE_URL
+              value: https://search.tahr-toad.ts.net/
+            - name: UWSGI_THREADS
+              value: "4"
+            - name: UWSGI_WORKERS
+              value: "4"
+          image: docker.io/searxng/searxng:latest
+          name: searxng
+          ports:
+            - containerPort: 8080
+              protocol: TCP
+              name: web
+          securityContext:
+            capabilities:
+              add:
+                - CHOWN
+                - SETGID
+                - SETUID
+              drop:
+                - ALL
+          volumeMounts:
+            - mountPath: /etc/searxng
+              name: searxng-claim0
+      restartPolicy: Always
+      volumes:
+        - name: searxng-claim0
+          persistentVolumeClaim:
+            claimName: searxng-claim0

--- a/searxng/searxng-namespace.yaml
+++ b/searxng/searxng-namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: searxng
+  namespace: searxng

--- a/searxng/searxng-service.yaml
+++ b/searxng/searxng-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    io.kompose.service: searxng
+  name: searxng
+  namespace: searxng
+spec:
+  ports:
+    - name: http
+      port: 8080
+      targetPort: web
+  selector:
+    io.kompose.service: searxng

--- a/searxng/valkey-data2-persistentvolumeclaim.yaml
+++ b/searxng/valkey-data2-persistentvolumeclaim.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: valkey-data2
+  name: valkey-data2
+  namespace: searxng
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi


### PR DESCRIPTION
This update introduces several new Kubernetes configuration files. These include the creation of a new application in ArgoCD, deployments for Redis and Searxng, services for both applications, and persistent volume claims. The sync policy is set to automated with prune and self-heal enabled. The deployment strategy for both applications is set to 'Recreate'.
