### PR TITLE
:gear: Added CHOWN to allowed capabilities in Redis deployment

### DIFF
--- a/searxng/redis-deployment.yaml
+++ b/searxng/redis-deployment.yaml
@@ -36,6 +36,7 @@ spec:
                 - SETGID
                 - SETUID
                 - DAC_OVERRIDE
+                - CHOWN
               drop:
                 - ALL
           volumeMounts:


### PR DESCRIPTION
In the Kubernetes configuration for the Redis deployment, an additional Linux capability, CHOWN, has been added to the list of allowed capabilities. This change will enable the container to change file ownership within its context. All other capabilities remain dropped as before.
