### PR TITLE
:gear: Added subPath to volumeMounts in deployment config

### DIFF
--- a/searxng/searxng-deployment.yaml
+++ b/searxng/searxng-deployment.yaml
@@ -40,8 +40,10 @@ spec:
           volumeMounts:
             - mountPath: /etc/searxng/settings.yml
               name: searxng-config
+              subPath: settings.yml
             - mountPath: /etc/searxng/limiter.toml
               name: searxng-limiter-config
+              subPath: limiter.toml
 
       restartPolicy: Always
       volumes:


### PR DESCRIPTION
The deployment configuration has been updated to include 'subPath' for both 'searxng-config' and 'searxng-limiter-config' volumeMounts. This change ensures that the correct files are mounted at the specified paths, improving the accuracy of our configurations.
