### PR TITLE
:sparkles: Added Ingress to Searxng

### DIFF
--- a/searxng/ingress.yaml
+++ b/searxng/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: searxng
+  namespace: searxng
+spec:
+  defaultBackend:
+    service:
+      name: searxng
+      port:
+        name: http
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - search

--- a/searxng/kustomization.yaml
+++ b/searxng/kustomization.yaml
@@ -8,6 +8,7 @@ resources:
   - searxng-namespace.yaml
   - searxng-service.yaml
   - valkey-data2-persistentvolumeclaim.yaml
+  - ingress.yaml
 configMapGenerator:
   - name: searxng-config
     files:


### PR DESCRIPTION
In this update, we've introduced an Ingress resource for the Searxng service in Kubernetes. This new addition will help manage external access to our services running within the cluster. The ingress is configured with a default backend pointing to the Searxng service on HTTP port. We've also updated the kustomization.yaml file to include this new ingress.yaml resource.
