### PR TITLE
:recycle: Refactor Ingress configuration

### DIFF
--- a/argocd/ingress.yaml
+++ b/argocd/ingress.yaml
@@ -1,37 +1,15 @@
-apiVersion: traefik.io/v1alpha1
-kind: IngressRoute
-metadata:
-  name: argocd-server
-  namespace: argocd
-spec:
-  entryPoints:
-    - websecure
-  routes:
-    - kind: Rule
-      match: Host(`argocd.mizar.scalar.cloud`)
-      priority: 10
-      services:
-        - name: argocd-server
-          port: 80
-    - kind: Rule
-      match: Host(`argocd.mizar.scalar.cloud`) && Header(`Content-Type`, `application/grpc`)
-      priority: 11
-      services:
-        - name: argocd-server
-          port: 80
-          scheme: h2c
-  tls:
-    secretName: argocd-tls
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: argocd
   namespace: argocd
 spec:
-  secretName: argocd-tls
-  dnsNames:
-    - "argocd.mizar.scalar.cloud"
-  issuerRef:
-    name: le-prod
-    kind: ClusterIssuer
+  defaultBackend:
+    service:
+      name: argocd-server
+      port:
+        name: http
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - argocd

--- a/dapr/ingress.yaml
+++ b/dapr/ingress.yaml
@@ -1,15 +1,15 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: grafana
-  namespace: monitoring
+  name: dapr
+  namespace: dapr-system
 spec:
   defaultBackend:
     service:
-      name: grafana
+      name: dapr-dashboard
       port:
-        name: http
+        number: 8080
   ingressClassName: tailscale
   tls:
     - hosts:
-        - grafana
+        - dapr

--- a/dapr/kustomization.yaml
+++ b/dapr/kustomization.yaml
@@ -2,4 +2,5 @@ kind: Kustomization
 resources:
   - configurations
   - statestores
+  - ingress.yaml
 apiVersion: kustomize.config.k8s.io/v1beta1

--- a/glance/ingress.yaml
+++ b/glance/ingress.yaml
@@ -1,32 +1,15 @@
-apiVersion: traefik.io/v1alpha1
-kind: IngressRoute
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: glance
   namespace: glance
 spec:
-  entryPoints:
-    - websecure
-  routes:
-    - kind: Rule
-      match: Host(`glance.mizar.scalar.cloud`)
-      priority: 10
-      services:
-        - name: glance
-          kind: Service
-          namespace: glance
-          port: http
+  defaultBackend:
+    service:
+      name: glance
+      port:
+        name: http
+  ingressClassName: tailscale
   tls:
-    secretName: glance-tls
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: glance
-  namespace: glance
-spec:
-  secretName: glance-tls
-  dnsNames:
-    - "glance.mizar.scalar.cloud"
-  issuerRef:
-    name: le-prod
-    kind: ClusterIssuer
+    - hosts:
+        - glance

--- a/kube-system/ingress.yaml
+++ b/kube-system/ingress.yaml
@@ -1,35 +1,15 @@
-apiVersion: traefik.io/v1alpha1
-kind: IngressRoute
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: hubble
   namespace: kube-system
 spec:
-  entryPoints:
-    - websecure
-  routes:
-    - kind: Rule
-      match: Host(`hubble.mizar.scalar.cloud`)
-      middlewares:
-        - name: authentik-auth-proxy
-          namespace: default
-      priority: 10
-      services:
-        - name: hubble-ui
-          kind: Service
-          namespace: kube-system
-          port: http
+  defaultBackend:
+    service:
+      name: hubble-ui
+      port:
+        name: http
+  ingressClassName: tailscale
   tls:
-    secretName: hubble-ui-tls
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: hubble-ui
-  namespace: kube-system
-spec:
-  secretName: hubble-ui-tls
-  dnsNames:
-    - "hubble.mizar.scalar.cloud"
-  issuerRef:
-    name: le-prod
-    kind: ClusterIssuer
+    - hosts:
+        - hubble

--- a/longhorn-system/ingress.yaml
+++ b/longhorn-system/ingress.yaml
@@ -1,35 +1,15 @@
-apiVersion: traefik.io/v1alpha1
-kind: IngressRoute
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
-  name: longhorn-frontend
+  name: longhorn
   namespace: longhorn-system
 spec:
-  entryPoints:
-    - websecure
-  routes:
-    - kind: Rule
-      match: Host(`longhorn.mizar.scalar.cloud`)
-      middlewares:
-        - name: authentik-auth-proxy
-          namespace: default
-      priority: 10
-      services:
-        - name: longhorn-frontend
-          kind: Service
-          namespace: longhorn-system
-          port: http
+  defaultBackend:
+    service:
+      name: longhorn-frontend
+      port:
+        name: http
+  ingressClassName: tailscale
   tls:
-    secretName: longhorn-frontend-tls
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: longhorn-frontend
-  namespace: longhorn-system
-spec:
-  secretName: longhorn-frontend-tls
-  dnsNames:
-    - "longhorn.mizar.scalar.cloud"
-  issuerRef:
-    name: le-prod
-    kind: ClusterIssuer
+    - hosts:
+        - longhorn

--- a/octobot/ingress.yaml
+++ b/octobot/ingress.yaml
@@ -1,35 +1,15 @@
-apiVersion: traefik.io/v1alpha1
-kind: IngressRoute
+apiVersion: networking.k8s.io/v1
+kind: Ingress
 metadata:
   name: octobot
   namespace: octobot
 spec:
-  entryPoints:
-    - websecure
-  routes:
-    - kind: Rule
-      match: Host(`octobot.mizar.scalar.cloud`)
-      middlewares:
-        - name: ak-outpost-authentik-embedded-outpost
-          namespace: authentik
-      priority: 10
-      services:
-        - name: octobot
-          kind: Service
-          namespace: octobot
-          port: http
+  defaultBackend:
+    service:
+      name: octobot
+      port:
+        name: http
+  ingressClassName: tailscale
   tls:
-    secretName: octobot-tls
----
-apiVersion: cert-manager.io/v1
-kind: Certificate
-metadata:
-  name: octobot
-  namespace: octobot
-spec:
-  secretName: octobot-tls
-  dnsNames:
-    - "octobot.mizar.scalar.cloud"
-  issuerRef:
-    name: le-prod
-    kind: ClusterIssuer
+    - hosts:
+        - octobot


### PR DESCRIPTION
The commit includes a significant overhaul of the Ingress configurations across multiple services. The changes involve switching from Traefik's IngressRoute to Kubernetes' native Ingress, and removing dependencies on cert-manager for TLS setup. A new file was also added to the Dapr service for its own ingress configuration.
