### PR TITLE
:sparkles: Added new DNSConfig for Tailscale

### DIFF
--- a/kube-system/ts-dns.yaml
+++ b/kube-system/ts-dns.yaml
@@ -1,0 +1,10 @@
+apiVersion: tailscale.com/v1alpha1
+kind: DNSConfig
+metadata:
+  name: ts-dns
+  namespace: kube-system
+spec:
+  nameserver:
+    image:
+      repo: tailscale/k8s-nameserver
+      tag: unstable


### PR DESCRIPTION
A new Kubernetes configuration file has been added to set up a custom DNS server using Tailscale's k8s-nameserver. This change will allow us to manage our own DNS within the kube-system namespace. The image tag used is currently set to 'unstable'.
