### PR TITLE
:sparkles: Added new service and updated ingress configurations

### DIFF
--- a/kube-system/reboot.yaml
+++ b/kube-system/reboot.yaml
@@ -1,0 +1,9 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    tailscale.com/tailnet-fqdn: "reboot.tahr-toad.ts.net"
+  name: ts-egress-reboot
+spec:
+  externalName: unused
+  type: ExternalName

--- a/monitoring/grafana-ingress.yaml
+++ b/monitoring/grafana-ingress.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: grafana
   namespace: monitoring
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
 spec:
   defaultBackend:
     service:

--- a/ollama/ingress.yaml
+++ b/ollama/ingress.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: ollama
   namespace: ollama
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
 spec:
   defaultBackend:
     service:


### PR DESCRIPTION
A new service has been added to the kube-system. Additionally, annotations have been included in the ingress configurations for both monitoring and ollama namespaces to enable experimental forwarding of cluster traffic via ingress.
