### PR TITLE
:sparkles: Added namespace to Service metadata

### DIFF
--- a/kube-system/reboot.yaml
+++ b/kube-system/reboot.yaml
@@ -1,6 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
+  namespace: kube-system
   annotations:
     tailscale.com/tailnet-fqdn: "reboot.tahr-toad.ts.net"
   name: ts-egress-reboot


### PR DESCRIPTION
The service metadata in the Kubernetes configuration file has been updated. A new 'namespace' field with value 'kube-system' has been added, which will help in better organization and isolation of resources within the Kubernetes cluster.
