### PR TITLE
:gear: Disable rate limiter in server settings

### DIFF
--- a/searxng/config/settings.yml
+++ b/searxng/config/settings.yml
@@ -1,7 +1,7 @@
 # see https://docs.searxng.org/admin/settings/settings.html#settings-use-default-settings
 use_default_settings: true
 server:
-  limiter: true  # can be disabled for a private instance
+  limiter: false  # can be disabled for a private instance
   image_proxy: true
 ui:
   static_use_hash: true


### PR DESCRIPTION
The rate limiter in the server configuration has been switched off. This change is typically suitable for private instances. No other significant changes were made.
