### PR TITLE
:sparkles: Added Searxng-Redis Application

### DIFF
--- a/apps/searxng-redis.yaml
+++ b/apps/searxng-redis.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: searxng-db
+  namespace: argocd
+spec:
+  destination:
+    namespace: databases
+    server: https://kubernetes.default.svc
+  source:
+    repoURL: https://registry-1.docker.io/bitnamicharts
+    targetRevision: 20.6.2
+    chart: redis
+    helm:
+      values: |
+        auth.enabled: false
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
A new Kubernetes application for Searxng-Redis has been added. This application is configured to use the Redis chart from Bitnami's Helm repository, with authentication disabled. The sync policy is set to automated with both prune and self-heal options enabled. A new namespace will be created during synchronization if it doesn't exist already.
