### PR TITLE
:twisted_rightwards_arrows: Updated Redis chart repository URL

### DIFF
--- a/apps/searxng-redis.yaml
+++ b/apps/searxng-redis.yaml
@@ -8,7 +8,7 @@ spec:
     namespace: databases
     server: https://kubernetes.default.svc
   source:
-    repoURL: https://registry-1.docker.io/bitnamicharts
+    repoURL: https://charts.bitnami.com/bitnami
     targetRevision: 20.6.2
     chart: redis
     helm:


### PR DESCRIPTION
The repository URL for the Redis chart in the Kubernetes configuration has been updated. The previous Bitnami Docker registry URL has been replaced with the official Bitnami charts repository URL. This change ensures that we are pulling from a more reliable and up-to-date source for our Redis deployments.
