### PR TITLE
:twisted_rightwards_arrows: Updated repoURL in searxng-redis config

### DIFF
--- a/apps/searxng-redis.yaml
+++ b/apps/searxng-redis.yaml
@@ -8,7 +8,7 @@ spec:
     namespace: databases
     server: https://kubernetes.default.svc
   source:
-    repoURL: https://charts.bitnami.com/bitnami
+    repoURL: registry-1.docker.io/bitnamicharts
     targetRevision: 20.6.1
     chart: redis
     helm:


### PR DESCRIPTION
The repository URL for the Redis chart in the searxng-redis configuration has been updated. The new URL points to a Docker registry instead of the previous Bitnami charts repository.
