### PR TITLE
:sparkles: Added new Application in ArgoCD

### DIFF
--- a/apps/coroot.yaml
+++ b/apps/coroot.yaml
@@ -1,0 +1,25 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: coroot
+  namespace: argocd
+spec:
+  destination:
+    namespace: coroot
+    server: https://kubernetes.default.svc
+  source:
+    repoURL: https://coroot.github.io/helm-charts
+    targetRevision: 0.3.0
+    chart: coroot-ce
+    helm:
+      values: |
+        clickhouse.shards: 2
+        clickhouse.replicas: 2
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
A new Application named 'coroot' has been added to the ArgoCD configuration. This application is set to deploy into a namespace of the same name on the default Kubernetes server. The source for this application is a Helm chart from coroot's GitHub repository, specifically version 0.3.0 of the 'coroot-ce' chart.

The sync policy for this application is automated with both prune and selfHeal options enabled, and it also includes an option to create its own namespace if it doesn't exist already. The helm values have been configured to use 2 shards and 2 replicas for clickhouse.
