### PR TITLE
:sparkles: Added Ingress Application and Configuration

### DIFF
--- a/apps/ingress.yaml
+++ b/apps/ingress.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ingress
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+  source:
+    path: ingress
+    repoURL: https://github.com/mizar-labs/mizar
+    targetRevision: HEAD
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/ingress/coroot.yaml
+++ b/ingress/coroot.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: coroot
+  namespace: coroot
+spec:
+  defaultBackend:
+    service:
+      name: coroot-coroot
+      port:
+        name: http
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - coroot


### PR DESCRIPTION
Introduced a new Ingress application in the ArgoCD namespace. This includes automated sync policy with prune and self-heal options enabled, along with the creation of namespaces.

Also added a new Ingress configuration for 'coroot' service in its own namespace. The configuration specifies default backend service details, ingress class name, and TLS hosts.
