### PR TITLE
:lock: Updated Redis authentication configuration

### DIFF
--- a/apps/searxng-redis.yaml
+++ b/apps/searxng-redis.yaml
@@ -13,7 +13,8 @@ spec:
     chart: redis
     helm:
       values: |
-        auth.enabled: false
+        auth:
+          enabled: false
   sources: []
   project: default
   syncPolicy:


### PR DESCRIPTION
The Redis authentication setting in the helm values has been restructured. The 'auth.enabled' property is now nested under 'auth', improving readability and consistency in the configuration file.
