### PR TITLE
:hammer_and_wrench: Refactored clickhouse configuration in YAML

### DIFF
--- a/apps/coroot.yaml
+++ b/apps/coroot.yaml
@@ -13,8 +13,10 @@ spec:
     chart: coroot-ce
     helm:
       values: |
-        clickhouse.shards: 2
-        clickhouse.replicas: 2
+        clickhouse:
+          shards: 2
+        clickhouse:
+          replicas: 2
   sources: []
   project: default
   syncPolicy:


### PR DESCRIPTION
The structure of the clickhouse configuration in the YAML file has been refactored for better readability and maintainability. The 'shards' and 'replicas' properties are now nested under individual 'clickhouse' keys.
