### PR TITLE
:fire: Removed duplicate clickhouse entry

### DIFF
--- a/apps/coroot.yaml
+++ b/apps/coroot.yaml
@@ -15,7 +15,6 @@ spec:
       values: |
         clickhouse:
           shards: 2
-        clickhouse:
           replicas: 2
   sources: []
   project: default


### PR DESCRIPTION
The commit removes a redundant configuration line for 'clickhouse' in the YAML file. This change simplifies the configuration and avoids potential confusion or errors due to repeated entries.
