### PR TITLE
:sparkles: Added new Ingress configuration

### DIFF
--- a/open-webui/ingress.yaml
+++ b/open-webui/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: open-webui
+  namespace: open-webui
+spec:
+  defaultBackend:
+    service:
+      name: open-webui
+      port:
+        name: http
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - ai


### PR DESCRIPTION
A new Kubernetes Ingress configuration has been added. This includes the specification of a default backend service, the assignment of an ingress class name, and the setup for TLS with specified hosts.
