### PR TITLE
:sparkles: Added new DNS service in open-webui

### DIFF
--- a/open-webui/dns.yaml
+++ b/open-webui/dns.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: open-webui
+  annotations:
+    tailscale.com/tailnet-fqdn: "idp.tahr-toad.ts.net"
+  name: ts-egress-idp
+spec:
+  externalName: unused
+  type: ExternalName


### PR DESCRIPTION
A new Kubernetes Service has been added to the 'open-webui' namespace. This service is of type 'ExternalName' and currently points to an unused external name. The service also includes a specific annotation for tailnet FQDN.
