### PR TITLE
:recycle: Updated namespace in DNS configuration

### DIFF
--- a/open-webui/dns.yaml
+++ b/open-webui/dns.yaml
@@ -1,7 +1,7 @@
 apiVersion: v1
 kind: Service
 metadata:
-  namespace: open-webui
+  namespace: kube-system
   annotations:
     tailscale.com/tailnet-fqdn: "idp.tahr-toad.ts.net"
   name: ts-egress-idp


### PR DESCRIPTION
The namespace for the Service in the DNS configuration has been updated from 'open-webui' to 'kube-system'. This change aligns with our recent system restructuring.
