### PR TITLE
:gear: Enable experimental traffic forwarding in ingress

### DIFF
--- a/searxng/ingress.yaml
+++ b/searxng/ingress.yaml
@@ -3,6 +3,8 @@ kind: Ingress
 metadata:
   name: searxng
   namespace: searxng
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
 spec:
   defaultBackend:
     service:


### PR DESCRIPTION
Added an annotation to the ingress configuration to enable experimental traffic forwarding. This change allows cluster traffic to be directed via the ingress, potentially improving network routing and performance.
