### PR TITLE
:gear: Increase UWSGI parameters

### DIFF
--- a/searxng/kustomization.yaml
+++ b/searxng/kustomization.yaml
@@ -14,6 +14,6 @@ configMapGenerator:
       - config/limiter.toml
   - name: searxng-tune
     literals:
-      - UWSGI_THREADS=4
-      - UWSGI_WORKERS=4
+      - UWSGI_THREADS=16
+      - UWSGI_WORKERS=16
 apiVersion: kustomize.config.k8s.io/v1beta1


### PR DESCRIPTION
The number of UWSGI threads and workers has been increased from 4 to 16. This change is expected to improve the performance by allowing more concurrent requests.
