### PR TITLE
:gear: Updated bot detection settings

### DIFF
--- a/searxng/config/limiter.toml
+++ b/searxng/config/limiter.toml
@@ -3,4 +3,8 @@
 
 [botdetection.ip_limit]
 # activate link_token method in the ip_limit method
-link_token = true
+link_token = false
+
+[botdetection.ip_lists]
+block_ip = []
+pass_ip = []


### PR DESCRIPTION
The bot detection configuration has been updated. The link_token method in the ip_limit section is now deactivated. Additionally, two new lists for blocking and passing IPs have been added to the ip_lists section.
