### PR TITLE
:recycle: Updated namespace in ConfigMap

### DIFF
--- a/homepage/configmap.yaml
+++ b/homepage/configmap.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: homepage
-  namespace: default
+  namespace: homepage
   labels:
     app.kubernetes.io/name: homepage
 data:


### PR DESCRIPTION
The namespace for the homepage ConfigMap has been updated from 'default' to 'homepage'. This change aligns the namespace with the application it's associated with, improving organization and clarity.
