### PR TITLE
:sparkles: Added Traefik application and ingress

### DIFF
--- a/apps/traefik.yaml
+++ b/apps/traefik.yaml
@@ -1,0 +1,19 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: traefik
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/mizar-labs/mizar
+    path: traefik
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: traefik
+  syncPolicy:
+    automated:
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/traefik/ingress.yaml
+++ b/traefik/ingress.yaml
@@ -1,0 +1,15 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: traefik-dash
+  namespace: traefik
+spec:
+  defaultBackend:
+    service:
+      name: traefik-dash
+      port:
+        name: dashboard
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - traefik


### PR DESCRIPTION
This commit introduces the Traefik application configuration in ArgoCD and its corresponding Kubernetes Ingress. The Application is set to automatically sync with the Mizar repository's HEAD revision, and a new namespace will be created if it doesn't exist. The Ingress is configured to route traffic to the Traefik dashboard service on the 'dashboard' port using Tailscale as the ingress class.
