### PR TITLE
:recycle: Removed Longhorn provider from config

### DIFF
--- a/homepage/configmap.yaml
+++ b/homepage/configmap.yaml
@@ -10,8 +10,6 @@ data:
     mode: cluster
   settings.yaml: |
     providers:
-      longhorn:
-        url: https://longhorn.my.network
       finnhub: {{ FINNHUB_API_KEY }}
   #settings.yaml: |
   #  providers:


### PR DESCRIPTION
The Longhorn provider configuration has been removed from the settings in the homepage's configmap.yaml. This change simplifies our configuration by eliminating an unused service.
