### PR TITLE
:lock: Updated API key variable name

### DIFF
--- a/homepage/configmap.yaml
+++ b/homepage/configmap.yaml
@@ -10,7 +10,7 @@ data:
     mode: cluster
   settings.yaml: |
     providers:
-      finnhub: {{ FINNHUB_API_KEY }}
+      finnhub: {{ HOMEPAGE_VAR_FINNHUB_API_KEY }}
   #settings.yaml: |
   #  providers:
   #    longhorn:


### PR DESCRIPTION
The environment variable for the Finnhub API key in the homepage configuration has been renamed to improve clarity and consistency. This change does not affect any functionality.
