### PR TITLE
:art: Cleaned up formatting in configmap

### DIFF
--- a/homepage/configmap.yaml
+++ b/homepage/configmap.yaml
@@ -10,7 +10,7 @@ data:
     mode: cluster
   settings.yaml: |
     providers:
-      finnhub: {{ HOMEPAGE_VAR_FINNHUB_API_KEY }}
+      finnhub: {{HOMEPAGE_VAR_FINNHUB_API_KEY}}
   #settings.yaml: |
   #  providers:
   #    longhorn:


### PR DESCRIPTION
Removed unnecessary spaces around a variable in the configuration map for better readability and consistency. No functional changes were made.
