### PR TITLE
:gear: Update behavior in kustomization.yaml

### DIFF
--- a/homepage/kustomization.yaml
+++ b/homepage/kustomization.yaml
@@ -7,7 +7,7 @@ resources:
   - service-account.yaml
 configMapGenerator:
   - name: homepage
-    behavior: replace
+    behavior: create
     files:
       - config/bookmarks.yaml
       - config/custom.css


### PR DESCRIPTION
The behavior for the 'homepage' configMapGenerator has been changed from 'replace' to 'create'. This change will affect how the configuration is applied during deployment.
