### PR TITLE
:recycle: Refactored namespace declaration in Kubernetes files

### DIFF
--- a/homepage/deployment.yaml
+++ b/homepage/deployment.yaml
@@ -2,7 +2,6 @@ apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: homepage
-  namespace: homepage
   labels:
     app.kubernetes.io/name: homepage
 spec:

--- a/homepage/ingress.yaml
+++ b/homepage/ingress.yaml
@@ -3,7 +3,6 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: homepage
-  namespace: homepage
   labels:
     app.kubernetes.io/name: homepage
   annotations:

--- a/homepage/kustomization.yaml
+++ b/homepage/kustomization.yaml
@@ -1,4 +1,5 @@
 kind: Kustomization
+namespace: homepage
 resources:
   - deployment.yaml
   - service.yaml

--- a/homepage/service-account.yaml
+++ b/homepage/service-account.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: ServiceAccount
 metadata:
   name: homepage
-  namespace: homepage
   labels:
     app.kubernetes.io/name: homepage
 secrets:

--- a/homepage/service.yaml
+++ b/homepage/service.yaml
@@ -2,7 +2,6 @@ apiVersion: v1
 kind: Service
 metadata:
   name: homepage
-  namespace: homepage
   labels:
     app.kubernetes.io/name: homepage
   annotations:


### PR DESCRIPTION
The namespace declaration has been removed from individual Kubernetes resource files (Deployment, Ingress, ServiceAccount, and Service) and centralized in the Kustomization file. This change simplifies the management of namespaces across different resources.
