### PR TITLE
:gear: Simplify resource access in role bindings

### DIFF
--- a/homepage/role-bindings.yaml
+++ b/homepage/role-bindings.yaml
@@ -8,9 +8,7 @@ rules:
   - apiGroups:
       - ""
     resources:
-      - namespaces
-      - pods
-      - nodes
+      - "*"
     verbs:
       - get
       - list
@@ -18,22 +16,21 @@ rules:
       - extensions
       - networking.k8s.io
     resources:
-      - ingresses
+      - "*"
     verbs:
       - get
       - list
   - apiGroups:
       - traefik.io
     resources:
-      - ingressroutes
+      - "*"
     verbs:
       - get
       - list
   - apiGroups:
       - metrics.k8s.io
     resources:
-      - nodes
-      - pods
+      - "*"
     verbs:
       - get
       - list


### PR DESCRIPTION
The role-bindings.yaml file has been updated to simplify the resources that can be accessed. Instead of listing specific resources like namespaces, pods, nodes, ingresses, and ingressroutes individually under different apiGroups, we now use a wildcard "*" to allow access to all resources under each apiGroup. This change should make the configuration more maintainable and flexible for future updates.
