### PR TITLE
:recycle: Simplified role bindings in Kubernetes config

### DIFF
--- a/homepage/role-bindings.yaml
+++ b/homepage/role-bindings.yaml
@@ -6,34 +6,11 @@ metadata:
     app.kubernetes.io/name: homepage
 rules:
   - apiGroups:
-      - ""
+      - "*"
     resources:
       - "*"
     verbs:
-      - get
-      - list
-  - apiGroups:
-      - extensions
-      - networking.k8s.io
-    resources:
       - "*"
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - traefik.io
-    resources:
-      - "*"
-    verbs:
-      - get
-      - list
-  - apiGroups:
-      - metrics.k8s.io
-    resources:
-      - "*"
-    verbs:
-      - get
-      - list
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
The role bindings configuration for the homepage application in Kubernetes has been significantly simplified. The changes include removing specific apiGroups and limiting the verbs to a universal set across all resources. This streamlines permissions and reduces complexity in our configuration.
