### PR TITLE
:gear: Update service configuration in YAML

### DIFF
--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -6,10 +6,15 @@
         type: traefik
         url: https://traefik.tahr-toad.ts.net
 
-- My Second Group:
-  - My Second Service:
-      href: http://localhost/
-      description: Homepage is the best
+- Global:
+  - NextDNS:
+      href: https://my.nextdns.io/
+      description: DNS Management
+      widget:
+        type: nextdns
+        profile: {{HOMEPAGE_VAR_NEXTDNS_PROFILE_MAIN}}
+        key: {{HOMEPAGE_VAR_NEXTDNS_KEY}}
+
 
 - My Third Group:
   - My Third Service:


### PR DESCRIPTION
The services.yaml file has been updated to replace the 'My Second Group' with a new 'Global' group. This includes the addition of a NextDNS service, complete with href, description and widget details. The widget type is set as nextdns and it uses two environment variables for profile and key.
