### PR TITLE
:sparkles: Added Longhorn and OpenMeteo widgets

### DIFF
--- a/homepage/config/settings.yaml
+++ b/homepage/config/settings.yaml
@@ -1,2 +1,4 @@
 providers:
   finnhub: {{HOMEPAGE_VAR_FINNHUB_API_KEY}}
+  longhorn:
+    url: https://longhorn.tahr-toad.ts.net

--- a/homepage/config/widgets.yaml
+++ b/homepage/config/widgets.yaml
@@ -1,3 +1,17 @@
+- datetime:
+    text_size: xl
+    format:
+      timeStyle: long
+      dateStyle: long
+- openmeteo:
+    label: Bryan # optional
+    latitude: 30.677446
+    longitude: -96.330783
+    timezone: America/Chicago # optional
+    units: imperial # or imperial
+    cache: 5 # Time in minutes to cache API responses, to stay within limits
+    format: # optional, Intl.NumberFormat options
+      maximumFractionDigits: 1
 - kubernetes:
     cluster:
       show: true
@@ -16,6 +30,16 @@
   cpu: true
   memory: true
   network: default
+- longhorn:
+    # Show the expanded view
+    expanded: true
+    # Shows a node representing the aggregate values
+    total: true
+    # Shows the node names as labels
+    labels: true
+    # Show the nodes
+    nodes: true
+
 - search:
     provider: duckduckgo
     target: _blank


### PR DESCRIPTION
Expanded the configuration settings to include new providers, specifically Longhorn. Also added a datetime widget with specific formatting and an OpenMeteo widget with location details. The Longhorn widget has been configured to show expanded view, aggregate values, node names as labels, and nodes.
