### PR TITLE
:sparkles: Added ArgoCD service to configuration

### DIFF
--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -5,6 +5,13 @@
       widget:
         type: traefik
         url: https://traefik.tahr-toad.ts.net
+  - ArgoCD:
+      href: https://argocd.tahr-toad.ts.net
+      description: ArgoCD Dashboard
+      widget:
+        type: argocd
+        url: http://argocd.host.or.ip:port
+        key: {{HOMEPAGE_VAR_ARGOCD_KEY}}
 
 - Global:
   - NextDNS:


### PR DESCRIPTION
The services configuration has been updated with a new entry for ArgoCD. This includes the necessary details such as href, description, widget type, url and key. The key is set up to use an environment variable for flexibility.
