### PR TITLE
:lock: Updated ArgoCD Dashboard URL to HTTPS

### DIFF
--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -10,7 +10,7 @@
       description: ArgoCD Dashboard
       widget:
         type: argocd
-        url: http://argocd.host.or.ip:port
+        url: https://argocd.tahr-toad.ts.net
         key: {{HOMEPAGE_VAR_ARGOCD_KEY}}
 
 - Global:


### PR DESCRIPTION
The ArgoCD Dashboard URL in the configuration file has been updated from HTTP to HTTPS for enhanced security.
