### PR TITLE
:twisted_rightwards_arrows: Updated homepage configuration

### DIFF
--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -37,7 +37,19 @@
         url: https://traefik.tahr-toad.ts.net
 
 
-- My Third Group:
-  - My Third Service:
-      href: http://localhost/
-      description: Homepage is 😎
+- Home:
+  - Calendar:
+      widget:
+        type: calendar
+        firstDayInWeek: sunday # optional - defaults to monday
+        view: monthly # optional - possible values monthly, agenda
+        maxEvents: 10 # optional - defaults to 10
+        showTime: true # optional - show time for event happening today - defaults to false
+        timezone: America/Chicago # optional and only when timezone is not detected properly (slightly slower performance) - force timezone for ical events (if it's the same - no change, if missing or different in ical - will be converted to this timezone)
+        integrations: # optional
+          - type: ical # Show calendar events from another service
+            url: {{HOMEPAGE_VAR_ICAL_URL}} # required - url to ical file
+            name: My Events # required - name for these calendar events
+            color: zinc # optional - defaults to pre-defined color for the service (zinc for ical)
+            params: # optional - additional params for the service
+              showName: true # optional - show name before event title in event line - defaults to false


### PR DESCRIPTION
The homepage configuration has been significantly updated. The previous 'My Third Group' section has been replaced with a new 'Home' section, which includes a detailed 'Calendar' widget. This widget offers various customization options such as the first day of the week, view type, maximum events to display, and timezone settings. It also supports integration with an external iCal service for displaying events.
