### PR TITLE
:recycle: Refactored homepage and widget configurations

### DIFF
--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -1,19 +1,19 @@
-- Cluster:
-  - Load Balancer:
-      href: https://traefik.tahr-toad.ts.net
-      description: Traefik Dashboard
+- Home:
+  - Calendar:
       widget:
-        type: traefik
-        url: https://traefik.tahr-toad.ts.net
-  - ArgoCD:
-      href: https://argocd.tahr-toad.ts.net
-      description: ArgoCD Dashboard
-      widget:
-        type: argocd
-        url: https://argocd.tahr-toad.ts.net
-        key: {{HOMEPAGE_VAR_ARGOCD_KEY}}
-
-- Global:
+        type: calendar
+        firstDayInWeek: sunday # optional - defaults to monday
+        view: monthly # optional - possible values monthly, agenda
+        maxEvents: 10 # optional - defaults to 10
+        showTime: true # optional - show time for event happening today - defaults to false
+        timezone: America/Chicago # optional and only when timezone is not detected properly (slightly slower performance) - force timezone for ical events (if it's the same - no change, if missing or different in ical - will be converted to this timezone)
+        integrations: # optional
+          - type: ical # Show calendar events from another service
+            url: {{HOMEPAGE_VAR_ICAL_URL}} # required - url to ical file
+            name: My Events # required - name for these calendar events
+            color: zinc # optional - defaults to pre-defined color for the service (zinc for ical)
+            params: # optional - additional params for the service
+              showName: true # optional - show name before event title in event line - defaults to false
   - NextDNS:
       href: https://my.nextdns.io/
       description: DNS Management
@@ -35,21 +35,10 @@
       widget:
         type: traefik
         url: https://traefik.tahr-toad.ts.net
-
-
-- Home:
-  - Calendar:
+  - ArgoCD:
+      href: https://argocd.tahr-toad.ts.net
+      description: ArgoCD Dashboard
       widget:
-        type: calendar
-        firstDayInWeek: sunday # optional - defaults to monday
-        view: monthly # optional - possible values monthly, agenda
-        maxEvents: 10 # optional - defaults to 10
-        showTime: true # optional - show time for event happening today - defaults to false
-        timezone: America/Chicago # optional and only when timezone is not detected properly (slightly slower performance) - force timezone for ical events (if it's the same - no change, if missing or different in ical - will be converted to this timezone)
-        integrations: # optional
-          - type: ical # Show calendar events from another service
-            url: {{HOMEPAGE_VAR_ICAL_URL}} # required - url to ical file
-            name: My Events # required - name for these calendar events
-            color: zinc # optional - defaults to pre-defined color for the service (zinc for ical)
-            params: # optional - additional params for the service
-              showName: true # optional - show name before event title in event line - defaults to false
+        type: argocd
+        url: https://argocd.tahr-toad.ts.net
+        key: {{HOMEPAGE_VAR_ARGOCD_KEY}}

--- a/homepage/config/widgets.yaml
+++ b/homepage/config/widgets.yaml
@@ -1,17 +1,15 @@
+- longhorn:
+    expanded: true
+    total: true
+    labels: true
+    nodes: true
+
 - datetime:
     text_size: xl
     format:
       timeStyle: long
       dateStyle: long
-- openmeteo:
-    label: Bryan # optional
-    latitude: 30.677446
-    longitude: -96.330783
-    timezone: America/Chicago # optional
-    units: imperial # or imperial
-    cache: 5 # Time in minutes to cache API responses, to stay within limits
-    format: # optional, Intl.NumberFormat options
-      maximumFractionDigits: 1
+
 - kubernetes:
     cluster:
       show: true
@@ -24,28 +22,24 @@
       cpu: true
       memory: true
       showLabel: true
+
+- openmeteo:
+    label: Bryan # optional
+    latitude: 30.677446
+    longitude: -96.330783
+    timezone: America/Chicago # optional
+    units: imperial # or imperial
+    cache: 5 # Time in minutes to cache API responses, to stay within limits
+    format: # optional, Intl.NumberFormat options
+      maximumFractionDigits: 1
+
 - resources:
   backend: resources
   expanded: true
   cpu: true
   memory: true
   network: default
-- longhorn:
-    # Show the expanded view
-    expanded: true
-    # Shows a node representing the aggregate values
-    total: true
-    # Shows the node names as labels
-    labels: true
-    # Show the nodes
-    nodes: true
 
-- search:
-    provider: custom
-    url: https://search.tahr-toad.ts.net/search?q=
-    target: _blank
-    #suggestionUrl: https://ac.ecosia.org/autocomplete?type=list&q= # Optional
-    #showSearchSuggestions: true # Optional
 - stocks:
     provider: finnhub
     color: true # optional, defaults to true
@@ -57,3 +51,11 @@
       - GME
       - AMC
       - NVDA
+
+- search:
+    provider: custom
+    url: https://search.tahr-toad.ts.net/search?q=
+    target: _blank
+    #suggestionUrl: https://ac.ecosia.org/autocomplete?type=list&q= # Optional
+    #showSearchSuggestions: true # Optional
+


### PR DESCRIPTION
The homepage and widget configurations have been restructured for better organization. The 'Calendar' section has been moved under the 'Home' category, while the 'ArgoCD' section is now placed under the global settings. In addition, changes were made to the widgets configuration file where some sections like 'longhorn', 'openmeteo', and 'search' were rearranged for improved readability.
