### PR TITLE
:recycle: Removed weather provider from widget config

### DIFF
--- a/homepage/config/widgets.yaml
+++ b/homepage/config/widgets.yaml
@@ -28,7 +28,6 @@
     latitude: 50.449684
     longitude: 30.525026
     units: metric # or imperial
-    provider: openweathermap
     apiKey: {{HOMEPAGE_VAR_OPENWEATHERMAP_API_KEY}}
     cache: 5 # Time in minutes to cache API responses, to stay within limits
     format: # optional, Intl.NumberFormat options


### PR DESCRIPTION
The weather provider field has been removed from the widget configuration. This simplifies the setup process as it's no longer necessary to specify a provider. The API key and other settings remain unchanged.
