### PR TITLE
:sparkles: Added Ollama API link and updated weather widget location

### DIFF
--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -42,3 +42,9 @@
         type: argocd
         url: https://argocd.tahr-toad.ts.net
         key: {{HOMEPAGE_VAR_ARGOCD_KEY}}
+
+- Links:
+  - Ollama:
+      icon: ollama.png
+      href: https://ollama.tahr-toad.ts.net
+      description: Ollama API

--- a/homepage/config/widgets.yaml
+++ b/homepage/config/widgets.yaml
@@ -24,10 +24,10 @@
       showLabel: true
 
 - openweathermap:
-    label: Kyiv #optional
-    latitude: 50.449684
-    longitude: 30.525026
-    units: metric # or imperial
+    label: Bryan
+    latitude: 30.677446
+    longitude: -96.330783
+    units: imperial
     apiKey: {{HOMEPAGE_VAR_OPENWEATHERMAP_API_KEY}}
     cache: 5 # Time in minutes to cache API responses, to stay within limits
     format: # optional, Intl.NumberFormat options


### PR DESCRIPTION
In this update, a new link to the Ollama API has been added in the services configuration. The icon and href for this service are now included. Additionally, the location details for the OpenWeatherMap widget have been modified - it's now set to Bryan with coordinates adjusted accordingly, and units changed to imperial.
