### PR TITLE
:recycle: Reordered widgets in configuration

### DIFF
--- a/homepage/config/widgets.yaml
+++ b/homepage/config/widgets.yaml
@@ -4,15 +4,6 @@
     labels: true
     nodes: true
 
-- openweathermap:
-    label: Bryan
-    latitude: 30.677446
-    longitude: -96.330783
-    units: imperial
-    apiKey: {{HOMEPAGE_VAR_OPENWEATHERMAP_API_KEY}}
-    cache: 5 # Time in minutes to cache API responses, to stay within limits
-    format: # optional, Intl.NumberFormat options
-      maximumFractionDigits: 1
 
 - kubernetes:
     cluster:
@@ -27,19 +18,22 @@
       memory: true
       showLabel: true
 
-- resources:
-  backend: resources
-  expanded: true
-  cpu: true
-  memory: true
-  network: default
-
 - search:
     provider: custom
     url: https://search.tahr-toad.ts.net/search?q=
     target: _blank
     #suggestionUrl: https://ac.ecosia.org/autocomplete?type=list&q= # Optional
     #showSearchSuggestions: true # Optional
+
+- openweathermap:
+    label: Bryan
+    latitude: 30.677446
+    longitude: -96.330783
+    units: imperial
+    apiKey: {{HOMEPAGE_VAR_OPENWEATHERMAP_API_KEY}}
+    cache: 5 # Time in minutes to cache API responses, to stay within limits
+    format: # optional, Intl.NumberFormat options
+      maximumFractionDigits: 1
 
 - datetime:
     text_size: xl


### PR DESCRIPTION
The widget order in the configuration file has been updated. The 'openweathermap' widget was moved down, while some other widgets were removed. No changes were made to the properties of any existing widgets.
