### PR TITLE
:recycle: Refactored service configuration

### DIFF
--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -1,9 +1,4 @@
 - Services:
-    - Ollama:
-        icon: ollama.png
-        href: https://ollama.tahr-toad.ts.net
-        description: Ollama API
-
 - Home:
   - Calendar:
       widget:

--- a/ollama/ingress.yaml
+++ b/ollama/ingress.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: ollama
   annotations:
     tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+    gethomepage.dev/description: Ollama API
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Services
+    gethomepage.dev/icon: ollama.png
+    gethomepage.dev/name: Ollama
+    gethomepage.dev/href: https://ollama.tahr-toad.ts.net
 spec:
   defaultBackend:
     service:


### PR DESCRIPTION
The service configuration has been refactored. The details of the 'Ollama' service have been moved from the homepage config to the ingress annotations. This change simplifies the homepage config and centralizes all service-related information in one place, making it easier to manage and update.
