### PR TITLE
:label: Update label selectors in Kubernetes configs

### DIFF
--- a/ollama/deployment.yaml
+++ b/ollama/deployment.yaml
@@ -7,11 +7,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      name: ollama
+      app.kubernetes.io/name: ollama
   template:
     metadata:
       labels:
-        name: ollama
+        app.kubernetes.io/name: ollama
     spec:
       volumes:
         - name: ollama

--- a/ollama/service.yaml
+++ b/ollama/service.yaml
@@ -10,7 +10,7 @@ spec:
       port: 80
       targetPort: http
   selector:
-    name: ollama
+    app.kubernetes.io/name: ollama
   type: ClusterIP
   sessionAffinity: None
   ipFamilies:


### PR DESCRIPTION
Updated the label selectors in both deployment and service Kubernetes configuration files. The 'name' key has been replaced with 'app.kubernetes.io/name' to align with recommended best practices for labeling.
