### PR TITLE
:sparkles: Added annotations to Ingress resources

### DIFF
--- a/argocd/ingress.yaml
+++ b/argocd/ingress.yaml
@@ -3,6 +3,14 @@ kind: Ingress
 metadata:
   name: argocd
   namespace: argocd
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+    gethomepage.dev/description: ArgoCD
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Services
+    gethomepage.dev/icon: argo-cd.png
+    gethomepage.dev/name: ArgoCD
+    gethomepage.dev/href: https://argocd.tahr-toad.ts.net
 spec:
   defaultBackend:
     service:

--- a/dapr/ingress.yaml
+++ b/dapr/ingress.yaml
@@ -3,6 +3,14 @@ kind: Ingress
 metadata:
   name: dapr
   namespace: dapr-system
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+    gethomepage.dev/description: Distributed Application Runtime
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Services
+    gethomepage.dev/icon: si-dapr.png
+    gethomepage.dev/name: Dapr
+    gethomepage.dev/href: https://dapr.tahr-toad.ts.net
 spec:
   defaultBackend:
     service:

--- a/glance/ingress.yaml
+++ b/glance/ingress.yaml
@@ -3,6 +3,14 @@ kind: Ingress
 metadata:
   name: glance
   namespace: glance
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+    gethomepage.dev/description: Smart Device HomePage
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Services
+    gethomepage.dev/icon: glance.png
+    gethomepage.dev/name: Glance
+    gethomepage.dev/href: https://glance.tahr-toad.ts.net
 spec:
   defaultBackend:
     service:

--- a/kube-system/ingress.yaml
+++ b/kube-system/ingress.yaml
@@ -3,6 +3,14 @@ kind: Ingress
 metadata:
   name: hubble
   namespace: kube-system
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+    gethomepage.dev/description: Kubernetes Network
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Services
+    gethomepage.dev/icon: cilium.png
+    gethomepage.dev/name: Hubble
+    gethomepage.dev/href: https://hubble.tahr-toad.ts.net
 spec:
   defaultBackend:
     service:

--- a/longhorn-system/ingress.yaml
+++ b/longhorn-system/ingress.yaml
@@ -3,6 +3,14 @@ kind: Ingress
 metadata:
   name: longhorn
   namespace: longhorn-system
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+    gethomepage.dev/description: Kubernetes Storage
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Services
+    gethomepage.dev/icon: longhorn.png
+    gethomepage.dev/name: Longhorn
+    gethomepage.dev/href: https://longhorn.tahr-toad.ts.net
 spec:
   defaultBackend:
     service:

--- a/octobot/ingress.yaml
+++ b/octobot/ingress.yaml
@@ -3,6 +3,14 @@ kind: Ingress
 metadata:
   name: octobot
   namespace: octobot
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+    gethomepage.dev/description: Crypto Trading Bot
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Services
+    gethomepage.dev/icon: sh-octobot.png
+    gethomepage.dev/name: Octobot
+    gethomepage.dev/href: https://octobot.tahr-toad.ts.net
 spec:
   defaultBackend:
     service:

--- a/searxng/ingress.yaml
+++ b/searxng/ingress.yaml
@@ -5,6 +5,12 @@ metadata:
   namespace: searxng
   annotations:
     tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+    gethomepage.dev/description: Search Engine
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Services
+    gethomepage.dev/icon: searxng.png
+    gethomepage.dev/name: Search
+    gethomepage.dev/href: https://search.tahr-toad.ts.net
 spec:
   defaultBackend:
     service:


### PR DESCRIPTION
New annotations have been added to multiple Ingress resources. These include details such as description, group, icon, name and href for each service. This will enhance the visibility and accessibility of these services. Additionally, an experimental feature from Tailscale has been enabled to forward cluster traffic via ingress.
