### PR TITLE
:recycle: Updated Ingress configurations

### DIFF
--- a/argocd/ingress.yaml
+++ b/argocd/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: argocd
+  name: argocd-server
   namespace: argocd
   annotations:
     tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"

--- a/open-webui/ingress.yaml
+++ b/open-webui/ingress.yaml
@@ -3,6 +3,14 @@ kind: Ingress
 metadata:
   name: open-webui
   namespace: open-webui
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+    gethomepage.dev/description: AI Web Interface
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Services
+    gethomepage.dev/icon: open-webui.png
+    gethomepage.dev/name: Open WebUI
+    gethomepage.dev/href: https://ai.tahr-toad.ts.net
 spec:
   defaultBackend:
     service:


### PR DESCRIPTION
The Ingress configurations have been updated for better service management. The name of the ArgoCD ingress has been changed to 'argocd-server'. Additionally, new annotations have been added to the Open WebUI ingress, providing more detailed metadata and enabling certain features.
