### PR TITLE
:label: Update Kubernetes label identifiers

### DIFF
--- a/glance/deployment.yaml
+++ b/glance/deployment.yaml
@@ -4,16 +4,16 @@ metadata:
   name: glance
   namespace: glance
   labels:
-    io.kompose.service: glance
+    app.kubernetes.io/name: glance
 spec:
   replicas: 1
   selector:
     matchLabels:
-      io.kompose.service: glance
+      app.kubernetes.io/name: glance
   template:
     metadata:
       labels:
-        io.kompose.service: glance
+        app.kubernetes.io/name: glance
     spec:
       volumes:
         - name: glance-config

--- a/glance/service.yaml
+++ b/glance/service.yaml
@@ -10,7 +10,7 @@ spec:
       port: 8080
       targetPort: http
   selector:
-    io.kompose.service: glance
+    app.kubernetes.io/name: glance
   type: ClusterIP
   sessionAffinity: None
   ipFamilies:

--- a/kube-system/ingress.yaml
+++ b/kube-system/ingress.yaml
@@ -1,7 +1,7 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: hubble
+  name: hubble-ui
   namespace: kube-system
   annotations:
     tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"

--- a/octobot/deployment.yaml
+++ b/octobot/deployment.yaml
@@ -4,16 +4,16 @@ metadata:
   name: octobot
   namespace: octobot
   labels:
-    io.kompose.service: octobot
+    app.kubernetes.io/name: octobot
 spec:
   replicas: 1
   selector:
     matchLabels:
-      io.kompose.service: octobot
+      app.kubernetes.io/name: octobot
   template:
     metadata:
       labels:
-        io.kompose.service: octobot
+        app.kubernetes.io/name: octobot
     spec:
       volumes:
         - name: octobot-claim0

--- a/octobot/service.yaml
+++ b/octobot/service.yaml
@@ -10,7 +10,7 @@ spec:
       port: 80
       targetPort: 5001
   selector:
-    io.kompose.service: octobot
+    app.kubernetes.io/name: octobot
   type: ClusterIP
   sessionAffinity: None
   ipFamilies:

--- a/open-webui/service.yaml
+++ b/open-webui/service.yaml
@@ -5,12 +5,10 @@ metadata:
   name: open-webui
   namespace: open-webui
   labels:
-    app.kubernetes.io/instance: open-webui
-    app.kubernetes.io/component: open-webui
+    app.kubernetes.io/name: open-webui
 spec:
   selector:
-    app.kubernetes.io/instance: open-webui
-    app.kubernetes.io/component: open-webui
+    app.kubernetes.io/name: open-webui
   type: ClusterIP
   ports:
     - protocol: TCP

--- a/open-webui/statefulset.yaml
+++ b/open-webui/statefulset.yaml
@@ -7,13 +7,11 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      app.kubernetes.io/component: open-webui
-      app.kubernetes.io/instance: open-webui
+      app.kubernetes.io/name: open-webui
   template:
     metadata:
       labels:
-        app.kubernetes.io/component: open-webui
-        app.kubernetes.io/instance: open-webui
+        app.kubernetes.io/name: open-webui
     spec:
       volumes:
         - name: data

--- a/searxng/searxng-deployment.yaml
+++ b/searxng/searxng-deployment.yaml
@@ -9,13 +9,13 @@ spec:
   replicas: 1
   selector:
     matchLabels:
-      io.kompose.service: searxng
+      app.kubernetes.io/name: searxng
   strategy:
     type: Recreate
   template:
     metadata:
       labels:
-        io.kompose.service: searxng
+        app.kubernetes.io/name: searxng
     spec:
       containers:
         - envFrom:

--- a/searxng/searxng-service.yaml
+++ b/searxng/searxng-service.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: Service
 metadata:
   labels:
-    io.kompose.service: searxng
+    app.kubernetes.io/name: searxng
   name: searxng
   namespace: searxng
 spec:
@@ -11,4 +11,4 @@ spec:
       port: 8080
       targetPort: web
   selector:
-    io.kompose.service: searxng
+    app.kubernetes.io/name: searxng


### PR DESCRIPTION
Updated the Kubernetes label identifiers across multiple deployment and service files. The old 'io.kompose.service' labels have been replaced with 'app.kubernetes.io/name' for better consistency and adherence to Kubernetes best practices. Also, the name of an Ingress resource in the kube-system namespace has been changed from 'hubble' to 'hubble-ui'.
