### PR TITLE
:recycle: Refactored service groupings and metadata

### DIFF
--- a/argocd/ingress.yaml
+++ b/argocd/ingress.yaml
@@ -7,7 +7,7 @@ metadata:
     tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
     gethomepage.dev/description: ArgoCD
     gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Services
+    gethomepage.dev/group: Operation
     gethomepage.dev/icon: argo-cd.png
     gethomepage.dev/name: ArgoCD
     gethomepage.dev/href: https://argocd.tahr-toad.ts.net

--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -16,6 +16,13 @@
               showName: true # optional - show name before event title in event line - defaults to false
 
 - Operation:
+  - ArgoCD:
+      href: https://argocd.tahr-toad.ts.net
+      description: ArgoCD Dashboard
+      widget:
+        type: argocd
+        url: https://argocd.tahr-toad.ts.net
+        key: {{HOMEPAGE_VAR_ARGOCD_KEY}}
   - NextDNS:
       href: https://my.nextdns.io/
       description: DNS Management
@@ -37,10 +44,3 @@
       widget:
         type: traefik
         url: https://traefik.tahr-toad.ts.net
-  - ArgoCD:
-      href: https://argocd.tahr-toad.ts.net
-      description: ArgoCD Dashboard
-      widget:
-        type: argocd
-        url: https://argocd.tahr-toad.ts.net
-        key: {{HOMEPAGE_VAR_ARGOCD_KEY}}

--- a/traefik/ingress.yaml
+++ b/traefik/ingress.yaml
@@ -1,8 +1,16 @@
 apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
-  name: traefik-dash
+  name: traefik
   namespace: traefik
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+    gethomepage.dev/description: Traefik Dashboard
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Operation
+    gethomepage.dev/icon: traefik.png
+    gethomepage.dev/name: Traefik
+    gethomepage.dev/href: https://traefik.tahr-toad.ts.net
 spec:
   defaultBackend:
     service:


### PR DESCRIPTION
The commit includes a significant reorganization of the service groups. The ArgoCD service has been moved from the 'Services' group to the 'Operation' group. Additionally, metadata for both ArgoCD and Traefik services have been updated to reflect these changes.
