### PR TITLE
:recycle: Refactored service configuration

### DIFF
--- a/argocd/ingress.yaml
+++ b/argocd/ingress.yaml
@@ -5,12 +5,6 @@ metadata:
   namespace: argocd
   annotations:
     tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
-    gethomepage.dev/description: ArgoCD
-    gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Operation
-    gethomepage.dev/icon: argo-cd.png
-    gethomepage.dev/name: ArgoCD
-    gethomepage.dev/href: https://argocd.tahr-toad.ts.net
 spec:
   defaultBackend:
     service:

--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -18,11 +18,28 @@
 - Operation:
   - ArgoCD:
       href: https://argocd.tahr-toad.ts.net
+      icon: argocd.png
       description: ArgoCD Dashboard
       widget:
         type: argocd
         url: https://argocd.tahr-toad.ts.net
         key: {{HOMEPAGE_VAR_ARGOCD_KEY}}
+  - Traefik:
+      href: https://traefik.tahr-toad.ts.net
+      icon: traefik.png
+      description: Traefik Dashboard
+      widget:
+        type: traefik
+        url: https://traefik.tahr-toad.ts.net
+  - Unifi:
+      href: https://udm.tahr-toad.ts.net
+      icon: unifi.png
+      description: Unifi Controller
+      widget:
+        type: unifi
+        url: https://udm.tahr-toad.ts.net
+        username: {{HOMEPAGE_VAR_UNIFI_USERNAME}}
+        password: {{HOMEPAGE_VAR_UNIFI_PASSWORD}}
   - NextDNS:
       href: https://my.nextdns.io/
       description: DNS Management
@@ -30,17 +47,5 @@
         type: nextdns
         profile: {{HOMEPAGE_VAR_NEXTDNS_PROFILE_MAIN}}
         key: {{HOMEPAGE_VAR_NEXTDNS_KEY}}
-  - Unifi:
-      href: https://udm.tahr-toad.ts.net
-      description: Unifi Controller
-      widget:
-        type: unifi
-        url: https://udm.tahr-toad.ts.net
-        username: {{HOMEPAGE_VAR_UNIFI_USERNAME}}
-        password: {{HOMEPAGE_VAR_UNIFI_PASSWORD}}
-  - Traefik:
-      href: https://traefik.tahr-toad.ts.net
-      description: Traefik Dashboard
-      widget:
-        type: traefik
-        url: https://traefik.tahr-toad.ts.net
+
+

--- a/traefik/ingress.yaml
+++ b/traefik/ingress.yaml
@@ -5,12 +5,6 @@ metadata:
   namespace: traefik
   annotations:
     tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
-    gethomepage.dev/description: Traefik Dashboard
-    gethomepage.dev/enabled: "true"
-    gethomepage.dev/group: Operation
-    gethomepage.dev/icon: traefik.png
-    gethomepage.dev/name: Traefik
-    gethomepage.dev/href: https://traefik.tahr-toad.ts.net
 spec:
   defaultBackend:
     service:


### PR DESCRIPTION
The service configuration has been refactored for better organization. Annotations related to the homepage have been removed from the ingress files and moved to the services.yaml file. The order of services in services.yaml has also been rearranged, with icons added for each service.
