### PR TITLE
:sparkles: Added new Service in kube-system

### DIFF
--- a/kube-system/proxmox.yaml
+++ b/kube-system/proxmox.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: kube-system
+  annotations:
+    tailscale.com/tailnet-fqdn: "pve.tahr-toad.ts.net"
+  name: ts-proxmox-egress
+spec:
+  externalName: unused
+  type: ExternalName


### PR DESCRIPTION
A new Kubernetes Service has been added to the kube-system namespace. This service, named 'ts-proxmox-egress', is of type ExternalName and carries specific annotations for tailscale.com. The external name is currently set as 'unused'.
