### PR TITLE
:twisted_rightwards_arrows: Refactored calendar widget configuration

### DIFF
--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -1,19 +1,32 @@
 - Home:
   - Calendar:
-      widget:
-        type: calendar
-        firstDayInWeek: sunday # optional - defaults to monday
-        view: monthly # optional - possible values monthly, agenda
-        maxEvents: 10 # optional - defaults to 10
-        showTime: true # optional - show time for event happening today - defaults to false
-        timezone: America/Chicago # optional and only when timezone is not detected properly (slightly slower performance) - force timezone for ical events (if it's the same - no change, if missing or different in ical - will be converted to this timezone)
-        integrations: # optional
-          - type: ical # Show calendar events from another service
-            url: {{HOMEPAGE_VAR_ICAL_URL}} # required - url to ical file
-            name: My Events # required - name for these calendar events
-            color: zinc # optional - defaults to pre-defined color for the service (zinc for ical)
-            params: # optional - additional params for the service
-              showName: true # optional - show name before event title in event line - defaults to false
+      widgets:
+        - type: calendar
+          firstDayInWeek: sunday # optional - defaults to monday
+          view: monthly # optional - possible values monthly, agenda
+          maxEvents: 10 # optional - defaults to 10
+          showTime: true # optional - show time for event happening today - defaults to false
+          timezone: America/Chicago # optional and only when timezone is not detected properly (slightly slower performance) - force timezone for ical events (if it's the same - no change, if missing or different in ical - will be converted to this timezone)
+          integrations: # optional
+            - type: ical # Show calendar events from another service
+              url: {{HOMEPAGE_VAR_ICAL_URL}} # required - url to ical file
+              name: My Events # required - name for these calendar events
+              color: zinc # optional - defaults to pre-defined color for the service (zinc for ical)
+              params: # optional - additional params for the service
+                showName: true # optional - show name before event title in event line - defaults to false
+        - type: calendar
+          view: agenda
+          maxEvents: 10 # optional - defaults to 10
+          showTime: true # optional - show time for event happening today - defaults to false
+          previousDays: 3 # optional - shows events since three days ago - defaults to 0
+          integrations: # same as in Monthly view example
+            - type: ical # Show calendar events from another service
+              url: {{HOMEPAGE_VAR_ICAL_URL}} # required - url to ical file
+              name: My Events # required - name for these calendar events
+              color: zinc # optional - defaults to pre-defined color for the service (zinc for ical)
+              params: # optional - additional params for the service
+                showName: true # optional - show name before event title in event line - defaults to false
+
 
 - Operation:
   - Proxmox:
@@ -39,16 +52,6 @@
       widget:
         type: traefik
         url: https://traefik.tahr-toad.ts.net
-  - Unifi:
-      href: https://udm.tahr-toad.ts.net
-      icon: unifi.png
-      description: Unifi Controller
-      widget:
-        type: unifi
-        fields: ["uptime", "wan", "lan", "wlan"]
-        url: https://udm.tahr-toad.ts.net
-        username: {{HOMEPAGE_VAR_UNIFI_USERNAME}}
-        password: {{HOMEPAGE_VAR_UNIFI_PASSWORD}}
   - NextDNS:
       href: https://my.nextdns.io/
       icon: nextdns.png


### PR DESCRIPTION
The configuration for the homepage's calendar widget has been refactored. The single widget object is now replaced with a widgets array, allowing multiple configurations. An additional 'agenda' view type calendar has also been added to the widgets array. Furthermore, the Unifi section under Operation was removed from services.yaml file.
