### PR TITLE
:twisted_rightwards_arrows: Refactored calendar widget configuration

### DIFF
--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -1,6 +1,6 @@
 - Home:
   - Calendar:
-      widgets:
+      widget:
         - type: calendar
           firstDayInWeek: sunday # optional - defaults to monday
           view: monthly # optional - possible values monthly, agenda
@@ -14,6 +14,8 @@
               color: zinc # optional - defaults to pre-defined color for the service (zinc for ical)
               params: # optional - additional params for the service
                 showName: true # optional - show name before event title in event line - defaults to false
+  - Agenda:
+      widget:
         - type: calendar
           view: agenda
           maxEvents: 10 # optional - defaults to 10


### PR DESCRIPTION
The calendar widget configuration in the homepage services has been refactored. The 'widgets' key was renamed to 'widget'. Additionally, an 'Agenda' section with a new calendar widget configured for an agenda view was added.
