### PR TITLE
:twisted_rightwards_arrows: Simplified calendar widget configuration

### DIFF
--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -1,33 +1,33 @@
 - Home:
   - Calendar:
       widget:
-        - type: calendar
-          firstDayInWeek: sunday # optional - defaults to monday
-          view: monthly # optional - possible values monthly, agenda
-          maxEvents: 10 # optional - defaults to 10
-          showTime: true # optional - show time for event happening today - defaults to false
-          timezone: America/Chicago # optional and only when timezone is not detected properly (slightly slower performance) - force timezone for ical events (if it's the same - no change, if missing or different in ical - will be converted to this timezone)
-          integrations: # optional
-            - type: ical # Show calendar events from another service
-              url: {{HOMEPAGE_VAR_ICAL_URL}} # required - url to ical file
-              name: My Events # required - name for these calendar events
-              color: zinc # optional - defaults to pre-defined color for the service (zinc for ical)
-              params: # optional - additional params for the service
-                showName: true # optional - show name before event title in event line - defaults to false
+        type: calendar
+        firstDayInWeek: sunday # optional - defaults to monday
+        view: monthly # optional - possible values monthly, agenda
+        maxEvents: 10 # optional - defaults to 10
+        showTime: true # optional - show time for event happening today - defaults to false
+        timezone: America/Chicago # optional and only when timezone is not detected properly (slightly slower performance) - force timezone for ical events (if it's the same - no change, if missing or different in ical - will be converted to this timezone)
+        integrations: # optional
+          - type: ical # Show calendar events from another service
+            url: {{HOMEPAGE_VAR_ICAL_URL}} # required - url to ical file
+            name: My Events # required - name for these calendar events
+            color: zinc # optional - defaults to pre-defined color for the service (zinc for ical)
+            params: # optional - additional params for the service
+              showName: true # optional - show name before event title in event line - defaults to false
   - Agenda:
       widget:
-        - type: calendar
-          view: agenda
-          maxEvents: 10 # optional - defaults to 10
-          showTime: true # optional - show time for event happening today - defaults to false
-          previousDays: 3 # optional - shows events since three days ago - defaults to 0
-          integrations: # same as in Monthly view example
-            - type: ical # Show calendar events from another service
-              url: {{HOMEPAGE_VAR_ICAL_URL}} # required - url to ical file
-              name: My Events # required - name for these calendar events
-              color: zinc # optional - defaults to pre-defined color for the service (zinc for ical)
-              params: # optional - additional params for the service
-                showName: true # optional - show name before event title in event line - defaults to false
+        type: calendar
+        view: agenda
+        maxEvents: 10 # optional - defaults to 10
+        showTime: true # optional - show time for event happening today - defaults to false
+        previousDays: 3 # optional - shows events since three days ago - defaults to 0
+        integrations: # same as in Monthly view example
+          - type: ical # Show calendar events from another service
+            url: {{HOMEPAGE_VAR_ICAL_URL}} # required - url to ical file
+            name: My Events # required - name for these calendar events
+            color: zinc # optional - defaults to pre-defined color for the service (zinc for ical)
+            params: # optional - additional params for the service
+              showName: true # optional - show name before event title in event line - defaults to false
 
 
 - Operation:


### PR DESCRIPTION
The structure of the calendar widget in the homepage configuration has been simplified. The changes include removing unnecessary nesting and maintaining all original options such as 'firstDayInWeek', 'view', 'maxEvents', etc. This should make it easier to understand and modify the configuration.
