### PR TITLE
:recycle: Simplified homepage configuration

### DIFF
--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -1,5 +1,4 @@
 - Home:
-  - Services:
   - Calendar:
       widget:
         type: calendar


### PR DESCRIPTION
Removed the 'Services' layer from the homepage configuration to streamline structure. The 'Calendar' widget is now directly under 'Home', enhancing readability and maintenance.
