### PR TITLE
:gear: Removed unused Operation section

### DIFF
--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -53,9 +53,6 @@
           type: traefik
           url: https://traefik.tahr-toad.ts.net
 
-
-- Operation:
-
 - DNS:
   - Main:
       href: https://my.nextdns.io/


### PR DESCRIPTION
The Operation section in the services configuration file was removed as it was not being used. This simplifies the configuration and reduces potential confusion.
