### PR TITLE
:gear: Adjusted indentation in services configuration

### DIFF
--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -52,7 +52,7 @@
         widget:
           type: traefik
           url: https://traefik.tahr-toad.ts.net
-  - DNS:
+    - DNS:
       - Main:
           href: https://my.nextdns.io/
           icon: nextdns.png


### PR DESCRIPTION
The YAML configuration for services has been updated. The indentation for the 'DNS' key was corrected to align with the structure of the document. This change ensures proper parsing and functioning of the service configurations.
