### PR TITLE
:gear: Fixed DNS configuration in services.yaml

### DIFF
--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -52,7 +52,7 @@
       widget:
         type: traefik
         url: https://traefik.tahr-toad.ts.net
-DNS:
+- DNS:
   - Main:
       href: https://my.nextdns.io/
       icon: nextdns.png


### PR DESCRIPTION
The commit includes a minor fix in the services configuration file. The DNS section was incorrectly formatted, causing potential issues with service discovery. This has been corrected by adding a dash before 'DNS'.
