### PR TITLE
:sparkles: Added Plex and Digital Tuner widgets

### DIFF
--- a/apps/plex.yaml
+++ b/apps/plex.yaml
@@ -28,6 +28,10 @@ spec:
             gethomepage.dev/icon: plex.png
             gethomepage.dev/name: Plex
             gethomepage.dev/href: https://plex.tahr-toad.ts.net
+            gethomepage.dev/pod-selector: "app.kubernetes.io/name=plex"
+            gethomepage.dev/widget.type: "plex"
+            gethomepage.dev/widget.url: "https://plex.tahr-toad.ts.net"
+            gethomepage.dev/widget.provider: "plex"
         pms:
           configStorage: 10Gi
         resources:

--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -52,6 +52,10 @@
       widget:
         type: traefik
         url: https://traefik.tahr-toad.ts.net
+  - Digital Tuner:
+      widget:
+        type: hdhomerun
+        provider: hdhomerun
 
 
 

--- a/homepage/config/settings.yaml
+++ b/homepage/config/settings.yaml
@@ -1,5 +1,7 @@
 providers:
   finnhub: {{HOMEPAGE_VAR_FINNHUB_API_KEY}}
+  hdhomerun: {{HOMEPAGE_VAR_HDHOMERUN_URL}}
+  plex: {{HOMEPAGE_VAR_PLEX_TOKEN}}
   longhorn:
     url: https://longhorn.tahr-toad.ts.net
 layout:


### PR DESCRIPTION
Expanded the functionality of the homepage by adding Plex and Digital Tuner widgets. This includes new pod-selector, widget type, url, and provider for Plex in plex.yaml. Also added a new Digital Tuner with its widget type and provider in services.yaml. Lastly, added hdhomerun URL and plex token to settings.yaml under providers.
