### PR TITLE
:tv: Updated digital tuner widget

### DIFF
--- a/homepage/config/services.yaml
+++ b/homepage/config/services.yaml
@@ -52,10 +52,13 @@
       widget:
         type: traefik
         url: https://traefik.tahr-toad.ts.net
-  - Digital Tuner:
+  - HDHomeRun:
+      icon: hdhomerun.png
+      href: {{HOMEPAGE_VAR_HDHOMERUN_URL}}
+      description: Digital TV Tuner
       widget:
         type: hdhomerun
-        provider: hdhomerun
+        url: {{HOMEPAGE_VAR_HDHOMERUN_URL}}
 
 
 


### PR DESCRIPTION
The digital tuner widget has been updated. The name has been changed from 'Digital Tuner' to 'HDHomeRun'. An icon and a description have also been added for better user understanding. The URL is now dynamically fetched using the HOMEPAGE_VAR_HDHOMERUN_URL variable.
