### PR TITLE
:whale: Updated Docker image tag for rclone

### DIFF
--- a/apps/plex.yaml
+++ b/apps/plex.yaml
@@ -40,6 +40,8 @@ spec:
             memory: 10Gi
         rclone:
           enabled: true
+          image:
+            tag: "1.69"
           configSecret: "rclone-config"
           remotes:
             - "proton:/plex"


### PR DESCRIPTION
The Docker image tag for the rclone service in the plex application has been updated. This change ensures that we are using the latest version of rclone, improving stability and performance.
