### PR TITLE
:whale: Updated Docker image tag in Plex app configuration

### DIFF
--- a/apps/plex.yaml
+++ b/apps/plex.yaml
@@ -15,6 +15,8 @@ spec:
       releaseName: plex
       values: |
         nameOverride: plex
+        image:
+          tag: "1.41.4.9463-630c9f557"
         ingress:
           enabled: true
           url: https://plex.tahr-toad.ts.net


### PR DESCRIPTION
The Docker image tag for the Plex application has been updated to version "1.41.4.9463-630c9f557". This change ensures that the Plex app is running on the latest and most stable version of its Docker image, improving overall performance and security.
