### PR TITLE
:sparkles: Added new Service in kube-system

### DIFF
--- a/kube-system/plex.yaml
+++ b/kube-system/plex.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: kube-system
+  annotations:
+    tailscale.com/tailnet-fqdn: "plex.tahr-toad.ts.net"
+  name: ts-egress-plex
+spec:
+  externalName: unused
+  type: ExternalName


### PR DESCRIPTION
A new Kubernetes Service has been added to the kube-system namespace. This service includes metadata annotations and is of type ExternalName. The external name is currently set as unused.
