### PR TITLE
:sparkles: Added new Application for Tautulli

### DIFF
--- a/apps/tautulli.yaml
+++ b/apps/tautulli.yaml
@@ -1,0 +1,42 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tautulli
+  namespace: argocd
+spec:
+  destination:
+    namespace: plex
+    server: https://kubernetes.default.svc
+  source:
+    repoURL: https://raw.githubusercontent.com/plexinc/pms-docker/gh-pages
+    targetRevision: 12.0.0
+    chart: tautulli
+    helm:
+      releaseName: tautulli
+      values: |
+        image:
+          repository: linuxserver/tautulli
+          tag: latest
+        env:
+          TZ: America/Chicago
+        persistence:
+          config:
+            enabled: true
+        ingress:
+          main:
+            enabled: true
+            primary: true
+            ingressClassName: tailscale
+            hosts:
+              - tautulli
+            tls:
+              - hosts:
+                  - tautulli
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
A new Kubernetes application has been added for Tautulli. The application is configured to deploy in the 'plex' namespace and uses the latest image from linuxserver/tautulli. It also includes environment settings, persistence configuration, and ingress setup with TLS support. Automated sync policy with prune and self-heal options are enabled as well.
