### PR TITLE
:bug: Fixed host configuration in YAML file

### DIFF
--- a/apps/tautulli.yaml
+++ b/apps/tautulli.yaml
@@ -28,7 +28,7 @@ spec:
             primary: true
             ingressClassName: tailscale
             hosts:
-              host: tautulli
+              - host: tautulli
             tls:
               - hosts:
                   - tautulli


### PR DESCRIPTION
The host configuration in the YAML file was corrected. Previously, it was incorrectly set as a single value but has now been changed to a list format. This change ensures proper parsing and handling of the host data.
