### PR TITLE
:sparkles: Added Tautulli application to ArgoCD

### DIFF
--- a/apps/tautulli.yaml
+++ b/apps/tautulli.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: tautulli
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/mizar-labs/mizar
+    path: tautulli
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: plex
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/tautulli/plex-namespace.yaml
+++ b/tautulli/plex-namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: plex
+  namespace: plex

--- a/tautulli/tautulli-claim0-persistentvolumeclaim.yaml
+++ b/tautulli/tautulli-claim0-persistentvolumeclaim.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: tautulli-claim0
+  name: tautulli-claim0
+  namespace: plex
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi

--- a/tautulli/tautulli-deployment.yaml
+++ b/tautulli/tautulli-deployment.yaml
@@ -1,0 +1,46 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose.yml convert -n plex
+    kompose.version: 1.34.0 (cbf2835db)
+  labels:
+    io.kompose.service: tautulli
+  name: tautulli
+  namespace: plex
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: tautulli
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose.yml convert -n plex
+        kompose.version: 1.34.0 (cbf2835db)
+      labels:
+        io.kompose.service: tautulli
+    spec:
+      containers:
+        - env:
+            - name: PGID
+              value: "1000"
+            - name: PUID
+              value: "1000"
+            - name: TZ
+              value: Etc/America
+          image: lscr.io/linuxserver/tautulli:latest
+          name: tautulli
+          ports:
+            - containerPort: 8181
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /config
+              name: tautulli-claim0
+      restartPolicy: Always
+      volumes:
+        - name: tautulli-claim0
+          persistentVolumeClaim:
+            claimName: tautulli-claim0

--- a/tautulli/tautulli-service.yaml
+++ b/tautulli/tautulli-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose.yml convert -n plex
+    kompose.version: 1.34.0 (cbf2835db)
+  labels:
+    io.kompose.service: tautulli
+  name: tautulli
+  namespace: plex
+spec:
+  ports:
+    - name: "8181"
+      port: 8181
+      targetPort: 8181
+  selector:
+    io.kompose.service: tautulli


### PR DESCRIPTION
This commit introduces the Tautulli application into our ArgoCD setup. The new files define a Kubernetes Application, Namespace, PersistentVolumeClaim, Deployment and Service for Tautulli. The deployment includes environment variables and volume mounts for configuration. Automated sync policy with prune and self-heal options are enabled in the Application definition.
