### PR TITLE
:twisted_rightwards_arrows: Updated namespace in app configuration

### DIFF
--- a/apps/tautulli.yaml
+++ b/apps/tautulli.yaml
@@ -11,7 +11,7 @@ spec:
     targetRevision: HEAD
   destination:
     server: https://kubernetes.default.svc
-    namespace: plex
+    namespace: tautulli
   syncPolicy:
     automated:
       prune: true


### PR DESCRIPTION
The namespace for the application has been updated from 'plex' to 'tautulli'. This change ensures that the application is deployed in the correct Kubernetes namespace. The sync policy remains unchanged.
