### PR TITLE
:recycle: Updated namespace from 'plex' to 'tautulli'

### DIFF
--- a/tautulli/plex-namespace.yaml
+++ b/tautulli/plex-namespace.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: plex
-  namespace: plex
+  namespace: tautulli

--- a/tautulli/tautulli-claim0-persistentvolumeclaim.yaml
+++ b/tautulli/tautulli-claim0-persistentvolumeclaim.yaml
@@ -4,7 +4,7 @@ metadata:
   labels:
     io.kompose.service: tautulli-claim0
   name: tautulli-claim0
-  namespace: plex
+  namespace: tautulli
 spec:
   accessModes:
     - ReadWriteOnce

--- a/tautulli/tautulli-deployment.yaml
+++ b/tautulli/tautulli-deployment.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     io.kompose.service: tautulli
   name: tautulli
-  namespace: plex
+  namespace: tautulli
 spec:
   replicas: 1
   selector:

--- a/tautulli/tautulli-service.yaml
+++ b/tautulli/tautulli-service.yaml
@@ -7,7 +7,7 @@ metadata:
   labels:
     io.kompose.service: tautulli
   name: tautulli
-  namespace: plex
+  namespace: tautulli
 spec:
   ports:
     - name: "8181"


### PR DESCRIPTION
The namespace in multiple YAML files has been updated from 'plex' to 'tautulli'. This change affects the Namespace, PersistentVolumeClaim, Deployment, and Service configurations.
