### PR TITLE
:gear: Adjusted syncPolicy settings in app configuration

### DIFF
--- a/apps/tautulli.yaml
+++ b/apps/tautulli.yaml
@@ -14,7 +14,7 @@ spec:
     namespace: tautulli
   syncPolicy:
     automated:
-      prune: true
-      selfHeal: true
+      prune: false
+      selfHeal: false
     syncOptions:
       - CreateNamespace=true


### PR DESCRIPTION
The automated syncPolicy settings for the application have been modified. The 'prune' and 'selfHeal' options, which were previously set to true, are now set to false. This change will affect how the application handles synchronization tasks.
