### PR TITLE
:sparkles: Added new Ingress and updated service port name

### DIFF
--- a/tautulli/ingress.yaml
+++ b/tautulli/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: tautulli
+  namespace: tautulli
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+spec:
+  defaultBackend:
+    service:
+      name: tautulli
+      port:
+        name: http
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - tautulli

--- a/tautulli/tautulli-service.yaml
+++ b/tautulli/tautulli-service.yaml
@@ -10,7 +10,7 @@ metadata:
   namespace: tautulli
 spec:
   ports:
-    - name: "8181"
+    - name: http
       port: 8181
       targetPort: 8181
   selector:


### PR DESCRIPTION
A new Ingress has been introduced with specific annotations, default backend configuration, and TLS settings. Additionally, the service port name in an existing file has been changed from a numeric value to 'http'.
