### PR TITLE
:sparkles: Added ChangeDetection application to Kubernetes

### DIFF
--- a/apps/changedetection.yaml
+++ b/apps/changedetection.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: changedetection
+  namespace: changedetection
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/mizar-labs/mizar
+    path: changedetection
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: changedetection
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/changedetection/changedetection-data-persistentvolumeclaim.yaml
+++ b/changedetection/changedetection-data-persistentvolumeclaim.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: changedetection-data
+  name: changedetection-data
+  namespace: changedetection
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/changedetection/changedetection-deployment.yaml
+++ b/changedetection/changedetection-deployment.yaml
@@ -1,0 +1,40 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose.yml convert -n changedetection
+    kompose.version: 1.34.0 (cbf2835db)
+  labels:
+    io.kompose.service: changedetection
+  name: changedetection
+  namespace: changedetection
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      io.kompose.service: changedetection
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      annotations:
+        kompose.cmd: kompose -f docker-compose.yml convert -n changedetection
+        kompose.version: 1.34.0 (cbf2835db)
+      labels:
+        io.kompose.service: changedetection
+    spec:
+      containers:
+        - image: ghcr.io/dgtlmoon/changedetection.io
+          name: changedetection
+          ports:
+            - containerPort: 5000
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /datastore
+              name: changedetection-data
+      hostname: changedetection
+      restartPolicy: Always
+      volumes:
+        - name: changedetection-data
+          persistentVolumeClaim:
+            claimName: changedetection-data

--- a/changedetection/changedetection-namespace.yaml
+++ b/changedetection/changedetection-namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: changedetection
+  namespace: changedetection

--- a/changedetection/changedetection-service.yaml
+++ b/changedetection/changedetection-service.yaml
@@ -1,0 +1,17 @@
+apiVersion: v1
+kind: Service
+metadata:
+  annotations:
+    kompose.cmd: kompose -f docker-compose.yml convert -n changedetection
+    kompose.version: 1.34.0 (cbf2835db)
+  labels:
+    io.kompose.service: changedetection
+  name: changedetection
+  namespace: changedetection
+spec:
+  ports:
+    - name: http
+      port: 5000
+      targetPort: 5000
+  selector:
+    io.kompose.service: changedetection

--- a/changedetection/ingress.yaml
+++ b/changedetection/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: changedetection
+  namespace: changedetection
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+spec:
+  defaultBackend:
+    service:
+      name: changedetection
+      port:
+        name: http
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - change


### PR DESCRIPTION
This commit introduces the ChangeDetection application into our Kubernetes environment. The following resources have been created:

- An Application resource for ArgoCD, defining the source repository and path, target revision, destination server and namespace, as well as sync policy.
- A PersistentVolumeClaim for data storage with a capacity of 10Gi.
- A Deployment resource that includes annotations from Kompose conversion, label selectors, strategy type and template specifications including container image details and volume mounts.
- A Namespace resource specifically for the ChangeDetection application.
- A Service resource exposing port 5000 with corresponding labels and annotations from Kompose conversion.
- An Ingress resource configured with Tailscale's experimental forward cluster traffic via ingress annotation.

These changes will allow us to monitor website changes within our Kubernetes cluster.
