### PR TITLE
:whale: Added Kavita application to Kubernetes

### DIFF
--- a/apps/kavita.yaml
+++ b/apps/kavita.yaml
@@ -1,0 +1,20 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: kavita
+  namespace: argocd
+spec:
+  project: default
+  source:
+    repoURL: https://github.com/mizar-labs/mizar
+    path: kavita
+    targetRevision: HEAD
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: kavita
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/kavita/kavita-deployment.yaml
+++ b/kavita/kavita-deployment.yaml
@@ -1,0 +1,53 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  labels:
+    app.kubernetes.io/name: kavita
+  name: kavita
+  namespace: kavita
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: kavita
+  strategy:
+    type: Recreate
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: kavita
+    spec:
+      containers:
+        - env:
+            - name: DOTNET_SYSTEM_GLOBALIZATION_INVARIANT
+              value: "true"
+            - name: TZ
+              value: America/Chicago
+          image: ghcr.io/kareadita/kavita:latest
+          name: kavita
+          ports:
+            - containerPort: 5000
+              protocol: TCP
+          volumeMounts:
+            - mountPath: /manga
+              name: manga
+            - mountPath: /comics
+              name: comics
+            - mountPath: /books
+              name: books
+            - mountPath: /kavita/config
+              name: config
+      restartPolicy: Always
+      volumes:
+        - name: manga
+          persistentVolumeClaim:
+            claimName: manga
+        - name: comics
+          persistentVolumeClaim:
+            claimName: comics
+        - name: books
+          persistentVolumeClaim:
+            claimName: books
+        - name: config
+          persistentVolumeClaim:
+            claimName: config

--- a/kavita/kavita-namespace.yaml
+++ b/kavita/kavita-namespace.yaml
@@ -1,0 +1,5 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kavita
+  namespace: kavita

--- a/kavita/kavita-service.yaml
+++ b/kavita/kavita-service.yaml
@@ -1,0 +1,14 @@
+apiVersion: v1
+kind: Service
+metadata:
+  labels:
+    app.kubernetes.io/name: kavita
+  name: kavita
+  namespace: kavita
+spec:
+  ports:
+    - name: http
+      port: 5000
+      targetPort: 5000
+  selector:
+    app.kubernetes.io/name: kavita

--- a/kavita/pvc-books.yaml
+++ b/kavita/pvc-books.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: books
+  name: books
+  namespace: kavita
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi

--- a/kavita/pvc-comics.yaml
+++ b/kavita/pvc-comics.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: comics
+  name: comics
+  namespace: kavita
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/kavita/pvc-config.yaml
+++ b/kavita/pvc-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    app.kubernetes.io/part-of: kavita
+  name: config
+  namespace: kavita
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 10Gi

--- a/kavita/pvc-manga.yaml
+++ b/kavita/pvc-manga.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  labels:
+    io.kompose.service: manga
+  name: manga
+  namespace: kavita
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Gi


### PR DESCRIPTION
This commit introduces the Kavita application into our Kubernetes setup. The changes include:
- Creation of a new Application resource for Kavita in ArgoCD
- Deployment configuration for the Kavita app, including environment variables and volume mounts
- Namespace definition for the Kavita app
- Service definition to expose the Kavita app within its namespace
- PersistentVolumeClaims for various data categories (books, comics, manga) and configuration storage
