### PR TITLE
:sparkles: Added new Ingress for Kavita service

### DIFF
--- a/kavita/ingress.yaml
+++ b/kavita/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: kavita
+  namespace: kavita
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+spec:
+  defaultBackend:
+    service:
+      name: kavita
+      port:
+        name: http
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - books


### PR DESCRIPTION
A new Kubernetes Ingress has been created for the Kavita service. This includes setting up a default backend with HTTP port and enabling experimental forwarding of cluster traffic via ingress. Also, TLS has been configured for specific hosts.
