### PR TITLE
:sparkles: Added new annotation to ingress.yaml

### DIFF
--- a/glance/ingress.yaml
+++ b/glance/ingress.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: glance
   annotations:
     tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+    tailscale.com/funnel: "true"
     gethomepage.dev/description: Smart Device HomePage
     gethomepage.dev/enabled: "true"
     gethomepage.dev/group: Services


### PR DESCRIPTION
A new annotation `tailscale.com/funnel` has been added to the metadata of the ingress configuration. This change is expected to enhance traffic routing capabilities.
