### PR TITLE
:sparkles: Added new n8n application configuration

### DIFF
--- a/apps/n8n.yaml
+++ b/apps/n8n.yaml
@@ -1,0 +1,108 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: n8n
+spec:
+  destination:
+    namespace: n8n
+    server: https://kubernetes.default.svc
+  source:
+    repoURL: 8gears.container-registry.com/library
+    targetRevision: 1.0.4
+    chart: n8n
+    helm:
+      releaseName: n8n
+      values: |
+        main:
+          config:
+            db:
+              type: postgresdb
+              postgresdb:
+                host: db-rw
+                user: n8n
+        #        password: password is read from cnpg db-app secretKeyRef
+                pool:
+                  size: 10
+                ssl:
+                  enabled: true
+                  reject_Unauthorized: true
+                  ca_file: "/home/ssl/certs/postgresql/ca.crt"
+          secret:
+            n8n:
+              encryption_key: "<your-secure-encryption-key>"
+
+          extraEnv:
+            DB_POSTGRESDB_PASSWORD:
+              valueFrom:
+                secretKeyRef:
+                  name: db-app
+                  key: password
+          # Mount the CNPG CA Cert into N8N container
+          extraVolumeMounts:
+            - name: db-ca-cert
+              mountPath: /home/ssl/certs/postgresql
+              readOnly: true
+
+          extraVolumes:
+            - name: db-ca-cert
+              secret:
+                secretName: db-ca
+                items:
+                  - key: ca.crt
+                    path: ca.crt
+          resources:
+            limits:
+              memory: 2048Mi
+            requests:
+              memory: 512Mi
+
+        ingress:
+          enabled: true
+          className: tailscale
+          annotations:
+            tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+            gethomepage.dev/description: Workflow Automation
+            gethomepage.dev/enabled: "true"
+            gethomepage.dev/group: Services
+            gethomepage.dev/icon: sh-n8n.png
+            gethomepage.dev/name: N8N
+            gethomepage.dev/href: https://n8n.tahr-toad.ts.net
+          hosts:
+            - host: n8n
+              paths:
+                - /
+          tls:
+            hosts:
+              - n8n
+
+
+        # cnpg DB cluster request
+        extraManifests:
+          - apiVersion: postgresql.cnpg.io/v1
+            kind: Cluster
+            metadata:
+              name: db
+            spec:
+              instances: 1
+              bootstrap:
+                initdb:
+                  database: n8n
+                  owner: n8n
+              postgresql:
+                parameters:
+                  shared_buffers: "64MB"
+              resources:
+                requests:
+                  memory: "512Mi"
+                limits:
+                  memory: "512Mi"
+              storage:
+                size: 1Gi
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
This commit introduces a new Application configuration for the n8n workflow automation tool. The setup includes:
- Deployment to the 'n8n' namespace on the default Kubernetes server
- Use of a specific version (1.0.4) from a custom container registry
- Configuration of PostgresDB as the database with SSL enabled and connection details specified
- Inclusion of resource limits and requests for memory usage
- Enabling ingress with specific annotations, hosts, and TLS settings
- Addition of an extraManifests section for PostgreSQL cluster request with its own resource specifications.
The sync policy is set to automated with prune and selfHeal options enabled.
