### PR TITLE
:gear: Disabled ingress in application configuration

### DIFF
--- a/apps/n8n.yaml
+++ b/apps/n8n.yaml
@@ -58,7 +58,7 @@ spec:
               memory: 512Mi
 
         ingress:
-          enabled: true
+          enabled: false
           className: tailscale
           annotations:
             tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"


### PR DESCRIPTION
The ingress setting within the application's YAML configuration file has been switched from enabled to disabled. This change affects how traffic is routed to the application, potentially impacting accessibility and network performance.
