### PR TITLE
:sparkles: Added new Ingress and Application configurations

### DIFF
--- a/apps/ingress.yaml
+++ b/apps/ingress.yaml
@@ -1,0 +1,17 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: ingress
+  namespace: argocd
+spec:
+  destination:
+    server: https://kubernetes.default.svc
+  source:
+    path: ingress
+    repoURL: https://github.com/mizar-labs/mizar
+    targetRevision: HEAD
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true

--- a/ingress/n8n.yaml
+++ b/ingress/n8n.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: n8n
+  namespace: n8n
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+    gethomepage.dev/description: Workflow Automation
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Services
+    gethomepage.dev/icon: sh-n8n.png
+    gethomepage.dev/name: N8N
+    gethomepage.dev/href: https://n8n.tahr-toad.ts.net
+spec:
+  defaultBackend:
+    service:
+      name: n8n
+      port:
+        name: http
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - n8n


### PR DESCRIPTION
Two new configuration files have been added. The first one is an ArgoCD Application for managing ingress resources, with automated sync policy enabled. The second file is a Kubernetes Ingress resource for the n8n service, including specific annotations and TLS setup.
