### PR TITLE
:sparkles: Added new Ingress and Service

### DIFF
--- a/ingress/wazuh.yaml
+++ b/ingress/wazuh.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wazuh
+  namespace: wazuh
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+    gethomepage.dev/description: Security Monitoring
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Services
+    gethomepage.dev/icon: wazuh.png
+    gethomepage.dev/name: Wazuh
+    gethomepage.dev/href: https://wazuh.tahr-toad.ts.net
+spec:
+  defaultBackend:
+    service:
+      name: dashboard
+      port:
+        name: dashboard
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - wazuh

--- a/kube-system/wazuh.yaml
+++ b/kube-system/wazuh.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: kube-system
+  annotations:
+    tailscale.com/tailnet-fqdn: "wazuh.tahr-toad.ts.net"
+  name: ts-egress-wazuh
+spec:
+  externalName: unused
+  type: ExternalName


### PR DESCRIPTION
Introduced a new Ingress in the 'wazuh' namespace with various annotations for security monitoring. The ingress is configured to forward cluster traffic and has TLS enabled.

Also added a new Service in the 'kube-system' namespace named 'ts-egress-wazuh'. This service is of type ExternalName with an unused external name.
