### PR TITLE
:sparkles: Added Wazuh services and Ingress

### DIFF
--- a/ingress/wazuh-dashboard.yaml
+++ b/ingress/wazuh-dashboard.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wazuh
+  namespace: wazuh
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+    gethomepage.dev/description: Security Monitoring
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Services
+    gethomepage.dev/icon: wazuh.png
+    gethomepage.dev/name: Wazuh
+    gethomepage.dev/href: https://wazuh.tahr-toad.ts.net
+spec:
+  defaultBackend:
+    service:
+      name: dashboard
+      port:
+        name: dashboard
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - wazuh

--- a/kube-system/wazuh-dashboard.yaml
+++ b/kube-system/wazuh-dashboard.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: kube-system
+  annotations:
+    tailscale.com/tailnet-fqdn: "wazuh.tahr-toad.ts.net"
+  name: ts-egress-wazuh
+spec:
+  externalName: unused
+  type: ExternalName

--- a/kube-system/wazuh-manager.yaml
+++ b/kube-system/wazuh-manager.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: kube-system
+  annotations:
+    tailscale.com/tailnet-fqdn: "wazuh-manager.tahr-toad.ts.net"
+  name: ts-egress-wazuh-manager
+spec:
+  externalName: unused
+  type: ExternalName

--- a/kube-system/wazuh-registration.yaml
+++ b/kube-system/wazuh-registration.yaml
@@ -1,0 +1,10 @@
+apiVersion: v1
+kind: Service
+metadata:
+  namespace: kube-system
+  annotations:
+    tailscale.com/tailnet-fqdn: "wazuh-registration.tahr-toad.ts.net"
+  name: ts-egress-wazuh-registration
+spec:
+  externalName: unused
+  type: ExternalName


### PR DESCRIPTION
Introduced new Kubernetes services for Wazuh dashboard, manager, and registration in the kube-system namespace. Also added an Ingress resource for the Wazuh dashboard in the wazuh namespace with specific annotations. These changes enable traffic forwarding and provide a more organized structure for security monitoring services.
