### PR TITLE
WIP on wazuh

### DIFF
--- a/ingress/wazuh-manager.yaml
+++ b/ingress/wazuh-manager.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wazuh-manager
+  namespace: wazuh
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+    gethomepage.dev/enabled: "false"
+spec:
+  defaultBackend:
+    service:
+      name: wazuh-workers
+      port:
+        name: agents-events
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - wazuh-manager

--- a/ingress/wazuh-registration.yaml
+++ b/ingress/wazuh-registration.yaml
@@ -1,0 +1,18 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: wazuh-registration
+  namespace: wazuh
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+    gethomepage.dev/enabled: "false"
+spec:
+  defaultBackend:
+    service:
+      name: wazuh
+      port:
+        name: registration
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - wazuh-registration


### PR DESCRIPTION
:construction: WIP on wazuh

Added two new Ingress resources for the wazuh namespace. The first one is for managing worker services and agent events, while the second one handles registration. Both are configured with specific annotations to forward cluster traffic via ingress and disable gethomepage.dev. TLS security has been set up for both resources as well.
