### PR TITLE
Reduces GPU resource allocation

### DIFF
--- a/ollama/gemma3.yaml
+++ b/ollama/gemma3.yaml
@@ -8,12 +8,9 @@ spec:
   image: gemma3
   imagePullPolicy: IfNotPresent
   resources:
-    limits:
-      nvidia.com/gpu: 1
     requests:
       cpu: 4
       memory: 8Gi
-      nvidia.com/gpu: 1
   storageClassName: longhorn
   affinity:
     nodeAffinity:


### PR DESCRIPTION
Removes the GPU limit to allow for more flexible resource allocation.

The gemma3 model will now request but not limit the number of GPUs.
