### PR TITLE
Updates storage class name

### DIFF
--- a/ollama/gemma3.yaml
+++ b/ollama/gemma3.yaml
@@ -14,8 +14,6 @@ spec:
       cpu: 4
       memory: 8Gi
       nvidia.com/gpu: 1
-  storageClassName: longhorn
-  persistentVolume:
-    accessMode: ReadWriteOnce
+  storageClassName: local-path
   runtimeClassName: nvidia
 


### PR DESCRIPTION
Updates the storage class name to `local-path`.

Removes the definition for persistent volume access mode, as this
is now handled by the local-path provisioner.
