### PR TITLE
Scales down the Foundry VTT deployment

### DIFF
--- a/foundryvtt/deployment.yaml
+++ b/foundryvtt/deployment.yaml
@@ -7,7 +7,7 @@ metadata:
     app.kubernetes.io/instance: foundry
     app.kubernetes.io/name: foundry-vtt
 spec:
-  replicas: 1
+  replicas: 0
   selector:
     matchLabels:
       app.kubernetes.io/instance: foundry


### PR DESCRIPTION
Reduces the number of running replicas to zero.

This change effectively stops the Foundry VTT instance,
potentially for maintenance, cost-saving, or other operational reasons.
