### PR TITLE
Updates GPU toleration for scheduling

### DIFF
--- a/ollama/gemma3.yaml
+++ b/ollama/gemma3.yaml
@@ -5,8 +5,9 @@ metadata:
   namespace: ollama
 spec:
   tolerations:
-  - key: "nvidia.com/gpu"
-    operator: Exists
+  - key: "gpu"
+    operator: "Equal"
+    value: "true"
     effect: NoSchedule
   replicas: 1
   image: gemma3


### PR DESCRIPTION
Changes the GPU toleration to use "Equal" operator to allow more specific scheduling based on node labels.

This ensures that pods are scheduled only on nodes that explicitly advertise having GPUs.
