### PR TITLE
Updates Helm chart source

### DIFF
--- a/apps/ollama.yaml
+++ b/apps/ollama.yaml
@@ -10,7 +10,7 @@ spec:
     path: ollama
     repoURL: helm.openwebui.com
     targetRevision: 0.6.4
-    chart: ollama
+    chart: open-webui
     helm:
       releaseName: ollama-stack
       valuesFile: ../helm-values/open-webui.yaml


### PR DESCRIPTION
Updates the Helm chart source from `ollama` to `open-webui`.

This change aligns the application definition with the correct Helm chart repository, ensuring the application is deployed from the intended source.
