### PR TITLE
✨ Adds Ingress for metrics service

### DIFF
--- a/ingress/open-webui.yaml
+++ b/ingress/open-webui.yaml
@@ -1,0 +1,23 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: coroot
+  namespace: coroot
+  annotations:
+    tailscale.com/experimental-forward-cluster-traffic-via-ingress: "true"
+    gethomepage.dev/description: Metrics
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/group: Services
+    gethomepage.dev/icon: coroot.png
+    gethomepage.dev/name: Coroot
+    gethomepage.dev/href: https://coroot.tahr-toad.ts.net
+spec:
+  defaultBackend:
+    service:
+      name: coroot-coroot
+      port:
+        name: http
+  ingressClassName: tailscale
+  tls:
+    - hosts:
+        - coroot


### PR DESCRIPTION
Adds an Ingress resource definition to expose the metrics service.

This allows external access to the service via a specified host and integrates with Tailscale for routing cluster traffic. It also adds configuration for Homepage.
