### PR TITLE
Updates ingress to use production certificate

### DIFF
--- a/ingress/coroot-traefik.yaml
+++ b/ingress/coroot-traefik.yaml
@@ -28,5 +28,5 @@ spec:
   dnsNames:
     - "coroot.mizar.scalar.cloud"
   issuerRef:
-    name: le-staging
+    name: le-prod
     kind: ClusterIssuer

--- a/ingress/plex-traefik.yaml
+++ b/ingress/plex-traefik.yaml
@@ -28,5 +28,5 @@ spec:
   dnsNames:
     - "plex.mizar.scalar.cloud"
   issuerRef:
-    name: le-staging
+    name: le-prod
     kind: ClusterIssuer


### PR DESCRIPTION
Changes the ingress configurations for coroot and plex to reference the production Let's Encrypt certificate issuer.
This ensures that these services use a valid and trusted certificate.
