### PR TITLE
Updates CurseForge page URL

### DIFF
--- a/apps/minecraft-nirvana.yaml
+++ b/apps/minecraft-nirvana.yaml
@@ -20,7 +20,7 @@ spec:
             apiKey:
               existingSecret: "minecraft-common"
               secretKey: CF_API_KEY
-              pageUrl: "https://www.curseforge.com/minecraft/modpacks/nirvana-vanilla"
+              pageUrl: "https://www.curseforge.com/minecraft/modpacks/nirvana-vanilla/files/6506359"
   sources: []
   project: default
   syncPolicy:


### PR DESCRIPTION
Updates the CurseForge page URL to point to the specific file associated with the latest version of the modpack.
This ensures users are directed to the correct download link.
