### PR TITLE
Adds Minecraft Router Application

### DIFF
--- a/apps/minecraft-router.yaml
+++ b/apps/minecraft-router.yaml
@@ -1,0 +1,26 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: minecraft-router
+  namespace: argocd
+spec:
+  destination:
+    namespace: minecraft
+    server: https://kubernetes.default.svc
+  source:
+    repoURL: https://itzg.github.io/minecraft-server-charts/
+    targetRevision: 4.26.3
+    chart: mc-router
+    helm:
+      values: |
+        minecraft:
+          type: LoadBalancer
+          port: 25565
+  sources: []
+  project: default
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true


### PR DESCRIPTION
Adds an ArgoCD application definition for deploying the mc-router chart.

This allows for automated deployment and management of a Minecraft
router service within the Kubernetes cluster. The router is configured
as a LoadBalancer on port 25565.
