### PR TITLE
Updates mc-router chart version

### DIFF
--- a/apps/minecraft-router.yaml
+++ b/apps/minecraft-router.yaml
@@ -9,7 +9,7 @@ spec:
     server: https://kubernetes.default.svc
   source:
     repoURL: https://itzg.github.io/minecraft-server-charts/
-    targetRevision: 4.26.3
+    targetRevision: 1.4.0
     chart: mc-router
     helm:
       values: |


### PR DESCRIPTION
Updates the mc-router Helm chart to the new major version.

This change might include breaking changes so users should refer to the chart documentation.
