### PR TITLE
Updates mc-router chart values

### DIFF
--- a/apps/minecraft-router.yaml
+++ b/apps/minecraft-router.yaml
@@ -13,9 +13,10 @@ spec:
     chart: mc-router
     helm:
       values: |
-        minecraft:
-          type: LoadBalancer
-          port: 25565
+        services:
+          minecraft:
+            type: LoadBalancer
+            port: 25565
   sources: []
   project: default
   syncPolicy:


### PR DESCRIPTION
Updates the mc-router chart values to correctly configure the service type and port.

This change ensures the Minecraft service is properly exposed using a LoadBalancer.
