### PR TITLE
Adds service annotations for mc-router

### DIFF
--- a/apps/minecraft-nirvana.yaml
+++ b/apps/minecraft-nirvana.yaml
@@ -14,6 +14,9 @@ spec:
     helm:
       values: |
         minecraftServer:
+          serviceAnnotations:
+           "mc-router.itzg.me/defaultServer": "true"
+           "mc-router.itzg.me/externalServerName": "vmc.scalar.cloud"
           eula: "TRUE"
           type: "AUTO_CURSEFORGE"
           autoCurseForge:


### PR DESCRIPTION
Adds service annotations to the minecraft-nirvana chart to enable mc-router integration.
This allows the service to be discovered and routed to by mc-router.
