### PR TITLE
Corrects YAML syntax for service annotations

### DIFF
--- a/apps/minecraft-nirvana.yaml
+++ b/apps/minecraft-nirvana.yaml
@@ -15,8 +15,8 @@ spec:
       values: |
         minecraftServer:
           serviceAnnotations:
-           "mc-router.itzg.me/defaultServer": "true"
-           "mc-router.itzg.me/externalServerName": "vmc.scalar.cloud"
+           mc-router.itzg.me/defaultServer: "true"
+           mc-router.itzg.me/externalServerName: "vmc.scalar.cloud"
           eula: "TRUE"
           type: "AUTO_CURSEFORGE"
           autoCurseForge:


### PR DESCRIPTION
Fixes incorrect YAML syntax for the service annotations, ensuring proper configuration for the Minecraft server's routing.
