### PR TITLE
Enables GPU support for Ollama pods

### DIFF
--- a/helm-values/open-webui.yaml
+++ b/helm-values/open-webui.yaml
@@ -7,7 +7,7 @@ ollama:
   fullnameOverride: "open-webui-ollama"
   gpu:
     # -- Enable GPU support for Ollama
-    enabled: false
+    enabled: true
     # -- GPU type (nvidia, amd, or true)
     type: nvidia
     # -- Number of GPUs to use

--- a/helm-values/open-webui.yaml
+++ b/helm-values/open-webui.yaml
@@ -24,7 +24,7 @@ ollama:
     size: 100Gi
   nodeSelector:
     # -- Node selector for Ollama pods
-    kubernetes.io/hostname: k-w-3
+    nvidia.com/gpu.family: turing
   tolerations:
     # -- Tolerations for Ollama pods
     - key: "gpu"


### PR DESCRIPTION
Updates the node selector to enable GPU support for Ollama pods.

- This change configures the system to schedule Ollama pods on nodes equipped with NVIDIA GPUs, specifically those belonging to the Turing architecture.
- It ensures that Ollama can leverage GPU acceleration for enhanced performance.