### PR TITLE
Quotes node selector value

### DIFF
--- a/helm-values/ollama.yaml
+++ b/helm-values/ollama.yaml
@@ -363,7 +363,7 @@ persistentVolume:
 
 # -- Node labels for pod assignment.
 nodeSelector:
-  kubernetes.io/hostname: k-w-3
+  kubernetes.io/hostname: "k-w-3"
 
 # -- Tolerations for pod assignment
 tolerations:


### PR DESCRIPTION
Ensures node selector value is properly quoted.
This prevents potential parsing issues with Kubernetes.
