### PR TITLE
Configures GPU node affinity

### DIFF
--- a/helm-values/ollama.yaml
+++ b/helm-values/ollama.yaml
@@ -363,14 +363,10 @@ persistentVolume:
 
 # -- Node labels for pod assignment.
 nodeSelector:
-  kubernetes.io/hostname: "k-w-3"
+  nvidia.com/gpu.family: "turing"
 
 # -- Tolerations for pod assignment
-tolerations:
-  - key: "gpu"
-    operator: "Equal"
-    value: "yes"
-    effect: "NoSchedule"
+tolerations: []
 
 # -- Affinity for pod assignment
 affinity: {}


### PR DESCRIPTION
Configures the node selector and tolerations to schedule pods on nodes with specific GPU family.

Removes the previous hardcoded hostname and specific toleration.
