### PR TITLE
Moves resources to the `ai` namespace

### DIFF
--- a/ingress/open-webui-traefik.yaml
+++ b/ingress/open-webui-traefik.yaml
@@ -2,7 +2,7 @@ apiVersion: traefik.io/v1alpha1
 kind: IngressRoute
 metadata:
   name: open-webui
-  namespace: open-webui
+  namespace: ai
 spec:
   entryPoints:
     - websecure
@@ -22,7 +22,7 @@ apiVersion: cert-manager.io/v1
 kind: Certificate
 metadata:
   name: open-webui
-  namespace: open-webui
+  namespace: ai
 spec:
   secretName: open-webui-tls
   dnsNames:

--- a/ingress/open-webui-traefik.yaml
+++ b/ingress/open-webui-traefik.yaml
@@ -13,7 +13,7 @@ spec:
       services:
         - name: open-webui
           kind: Service
-          namespace: open-webui
+          namespace: ai
           port: http
   tls:
     secretName: open-webui-tls


### PR DESCRIPTION
Updates the namespace of the IngressRoute and Certificate resources.

This change ensures that resources are deployed within the designated `ai` namespace.