### PR TITLE
🚀 Switches to production Let's Encrypt issuer

### DIFF
--- a/ingress/open-webui-traefik.yaml
+++ b/ingress/open-webui-traefik.yaml
@@ -28,5 +28,5 @@ spec:
   dnsNames:
     - "ai.mizar.scalar.cloud"
   issuerRef:
-    name: le-staging
+    name: le-prod
     kind: ClusterIssuer


### PR DESCRIPTION
Updates the Ingress configuration to utilize the production Let's Encrypt cluster issuer.

This ensures that certificates are obtained from the official Let's Encrypt service, rather than the staging environment.
