### PR TITLE
🛠️ Disables Redis network policy by default

### DIFF
--- a/apps/open-webui.yaml
+++ b/apps/open-webui.yaml
@@ -71,6 +71,9 @@ spec:
           redis:
             # -- Enable redis installation
             enabled: true
+            # -- Network policy for redis
+            networkPolicy:
+              enabled: false
             # -- Redis name
             name: open-webui-redis
             # -- Redis labels


### PR DESCRIPTION
Disables the default creation of network policies for Redis.

This provides more flexibility for users who do not require network isolation for their Redis instance.
