### PR TITLE
Configures network policy for Redis cluster

### DIFF
--- a/apps/open-webui.yaml
+++ b/apps/open-webui.yaml
@@ -72,8 +72,7 @@ spec:
             # -- Enable redis installation
             enabled: true
             # -- Network policy for redis
-            networkPolicy:
-              enabled: false
+
             # -- Redis name
             name: open-webui-redis
             # -- Redis labels
@@ -125,6 +124,9 @@ spec:
         redis-cluster:
           # -- Enable Redis installation
           enabled: true
+          # the network policy for redis
+          networkPolicy:
+            enabled: false
           # -- Redis cluster name (recommended to be 'open-webui-redis')
           # - In this case, redis url will be 'redis://open-webui-redis-master:6379/0' or 'redis://[:<password>@]open-webui-redis-master:6379/0'
           fullnameOverride: open-webui-redis


### PR DESCRIPTION
Ensures network policy settings are correctly applied to the
Redis cluster deployment.

This change explicitly configures the network policy setting
for the Redis cluster to align with the intended network
configuration.
