### PR TITLE
✨ Enables OAuth signup

### DIFF
--- a/apps/open-webui.yaml
+++ b/apps/open-webui.yaml
@@ -364,6 +364,11 @@ spec:
                secretKeyRef:
                  name: open-webui
                  key: WEBUI_URL
+           - name: ENABLE_OAUTH_SIGNUP
+             valueFrom:
+               secretKeyRef:
+                 name: open-webui
+                 key: ENABLE_OAUTH_SIGNUP
           # - name: OLLAMA_DEBUG
           #   value: "1"
 


### PR DESCRIPTION
Enables the OAuth signup feature by adding the `ENABLE_OAUTH_SIGNUP` environment variable.
This allows users to register and authenticate using OAuth providers.
