### PR TITLE
Fixes invalid character in OAuth config

### DIFF
--- a/apps/open-webui.yaml
+++ b/apps/open-webui.yaml
@@ -502,7 +502,7 @@ spec:
             enabled: true
             # -- GitHub OAuth client ID
             # @section -- GitHub OAuth configuration
-            clientId: Ov23li06pud5lzLadcQz"
+            clientId: Ov23li06pud5lzLadcQz
             # -- GitHub OAuth client secret (ignored if clientExistingSecret is set)
             # @section -- GitHub OAuth configuration
             clientSecret: ""


### PR DESCRIPTION
Corrects an invalid character within the GitHub OAuth client ID configuration, ensuring proper functionality of the authentication process.
