### PR TITLE
✨ Adds Traefik ingress routes

### DIFF
--- a/ingress/n8n-traefik.yaml
+++ b/ingress/n8n-traefik.yaml
@@ -1,0 +1,32 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: n8n
+  namespace: n8n
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`n8n.mizar.scalar.cloud`)
+      priority: 10
+      services:
+        - name: n8n
+          kind: Service
+          namespace: n8n
+          port: http
+  tls:
+    secretName: n8n-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: n8n
+  namespace: n8n
+spec:
+  secretName: n8n-tls
+  dnsNames:
+    - "n8n.mizar.scalar.cloud"
+  issuerRef:
+    name: le-staging
+    kind: ClusterIssuer

--- a/ingress/searxng-traefik.yaml
+++ b/ingress/searxng-traefik.yaml
@@ -1,0 +1,32 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: searxng
+  namespace: searxng
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`search.mizar.scalar.cloud`)
+      priority: 10
+      services:
+        - name: searxng
+          kind: Service
+          namespace: searxng
+          port: http
+  tls:
+    secretName: searxng-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: searxng
+  namespace: searxng
+spec:
+  secretName: searxng-tls
+  dnsNames:
+    - "search.mizar.scalar.cloud"
+  issuerRef:
+    name: le-staging
+    kind: ClusterIssuer


### PR DESCRIPTION
Adds Traefik ingress routes and cert-manager certificates for n8n and searxng services.

This allows routing traffic to the services and automatically provisions TLS certificates.
