### PR TITLE
✨ Adds pod selector for homepage integration

### DIFF
--- a/ingress/coroot-traefik.yaml
+++ b/ingress/coroot-traefik.yaml
@@ -10,6 +10,7 @@ metadata:
     gethomepage.dev/group: Services
     gethomepage.dev/app: coroot-coroot # optional, may be needed if app.kubernetes.io/name != ingress metadata.name
     gethomepage.dev/name: Coroot
+    gethomepage.dev/pod-selector: "app.kubernetes.io/part-of=coroot"
 spec:
   entryPoints:
     - websecure


### PR DESCRIPTION
Adds a pod selector to the ingress configuration.

This allows the homepage application to correctly identify and associate the ingress with the relevant pods.
