### PR TITLE
Adds namespace to homepage ingress

### DIFF
--- a/ingress/homepage.yaml
+++ b/ingress/homepage.yaml
@@ -3,6 +3,7 @@ apiVersion: networking.k8s.io/v1
 kind: Ingress
 metadata:
   name: homepage
+  namespace: homepage
   labels:
     app.kubernetes.io/name: homepage
   annotations:


### PR DESCRIPTION
Adds a namespace to the homepage ingress configuration.

This ensures that the ingress resource is created within the correct namespace, improving resource organization and management within the cluster.
