### PR TITLE
Removes ingress resource

### DIFF
--- a/searxng/kustomization.yaml
+++ b/searxng/kustomization.yaml
@@ -4,7 +4,6 @@ resources:
   - searxng-deployment.yaml
   - searxng-namespace.yaml
   - searxng-service.yaml
-  - ingress.yaml
 configMapGenerator:
   - name: searxng-config
     files:


### PR DESCRIPTION
Removes the ingress resource from the kustomization file.

This simplifies deployment by removing a networking configuration managed elsewhere.
