### PR TITLE
✨ Adds Paperless-ngx ingress

### DIFF
--- a/ingress/paperless.yaml
+++ b/ingress/paperless.yaml
@@ -1,0 +1,39 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: paperless-ngx
+  namespace: paperless
+  annotations:
+    gethomepage.dev/href: "https://docs.mizar.scalar.cloud"
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/icon: paperless.png
+    gethomepage.dev/description: Document Management System
+    gethomepage.dev/group: Services
+    gethomepage.dev/name: Paperless
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`docs.mizar.scalar.cloud`)
+      priority: 10
+      services:
+        - name: prod-paperless-ngx
+          kind: Service
+          namespace: paperless
+          port: http
+  tls:
+    secretName: paperless-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: paperless
+  namespace: paperless
+spec:
+  secretName: paperless-tls
+  dnsNames:
+    - "docs.mizar.scalar.cloud"
+  issuerRef:
+    name: le-staging
+    kind: ClusterIssuer


### PR DESCRIPTION
Adds ingress and certificate resources for Paperless-ngx.

Exposes Paperless-ngx through a Traefik IngressRoute and
request a certificate from Let's Encrypt using cert-manager.
