### PR TITLE
Removes securityContext restrictions

### DIFF
--- a/searxng/searxng-deployment.yaml
+++ b/searxng/searxng-deployment.yaml
@@ -35,8 +35,8 @@ spec:
                 - CHOWN
                 - SETGID
                 - SETUID
-              drop:
-                - ALL
+#              drop:
+#                - ALL
           volumeMounts:
             - mountPath: /etc/searxng/settings.yml
               name: searxng-config


### PR DESCRIPTION
Relaxes securityContext restrictions by commenting out the `drop` capability.

This change allows the application to run with broader privileges, which may be necessary in certain environments or for specific functionalities.

It is important to carefully consider the security implications before deploying this change in a production environment.
