### PR TITLE
Disables Redis cluster installation

### DIFF
--- a/apps/open-webui.yaml
+++ b/apps/open-webui.yaml
@@ -123,7 +123,7 @@ spec:
         # -- Deploys a Redis cluster with subchart 'redis' from bitnami
         redis-cluster:
           # -- Enable Redis installation
-          enabled: true
+          enabled: false
           # the network policy for redis
           networkPolicy:
             enabled: false


### PR DESCRIPTION
Deactivates the Redis cluster subchart installation.

This change prevents the deployment of a Redis cluster by default,
potentially relying on an external Redis instance or other data store.
