### PR TITLE
✨ Adds Matrix Web IngressRoute

### DIFF
--- a/ingress/matrix-web-traefik.yaml
+++ b/ingress/matrix-web-traefik.yaml
@@ -1,0 +1,41 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: matrix-web
+  namespace: matrix
+  annotations:
+    gethomepage.dev/href: "https://web.matrix.scalar.cloud"
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/icon: synapse.png
+    gethomepage.dev/description: Chat Web Interface
+    gethomepage.dev/group: Services
+    #gethomepage.dev/app: coroot-coroot # optional, may be needed if app.kubernetes.io/name != ingress metadata.name
+    gethomepage.dev/name: Matrix Web
+    #gethomepage.dev/pod-selector: "app.kubernetes.io/part-of=coroot"
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`web.matrix.scalar.cloud`)
+      priority: 10
+      services:
+        - name: prod-element
+          kind: Service
+          namespace: matrix
+          port: http
+  tls:
+    secretName: matrix-web-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: matrix-web
+  namespace: matrix
+spec:
+  secretName: matrix-web-tls
+  dnsNames:
+    - "web.matrix.scalar.cloud"
+  issuerRef:
+    name: le-staging
+    kind: ClusterIssuer


### PR DESCRIPTION
Adds an IngressRoute for Matrix Web using Traefik.

This configuration enables access to the Matrix Web service
through the `web.matrix.scalar.cloud` domain, secured with TLS.
It also sets up a Certificate resource for automatic certificate
management via cert-manager.
