### PR TITLE
🛠️ Updates Matrix base URL and issuer

### DIFF
--- a/apps/matrix.yaml
+++ b/apps/matrix.yaml
@@ -187,7 +187,7 @@ spec:
           config:
             default_server_config:
               m.homeserver:
-                base_url: https://web.matrix.scalar.cloud/
+                base_url: https://matrix.scalar.cloud/
                 server_name: Matrix
   project: default
   syncPolicy:

--- a/ingress/matrix-web-traefik.yaml
+++ b/ingress/matrix-web-traefik.yaml
@@ -37,5 +37,5 @@ spec:
   dnsNames:
     - "web.matrix.scalar.cloud"
   issuerRef:
-    name: le-staging
+    name: le-prod
     kind: ClusterIssuer


### PR DESCRIPTION
Updates the Matrix base URL to reflect the new domain.

Changes the Let's Encrypt issuer to production.
