### PR TITLE
✨ Adds Matrix Traefik IngressRoute

### DIFF
--- a/ingress/matrix-traefik.yaml
+++ b/ingress/matrix-traefik.yaml
@@ -1,0 +1,41 @@
+apiVersion: traefik.io/v1alpha1
+kind: IngressRoute
+metadata:
+  name: matrix
+  namespace: matrix
+  annotations:
+    gethomepage.dev/href: "https://matrix.scalar.cloud"
+    gethomepage.dev/enabled: "true"
+    gethomepage.dev/icon: synapse.png
+    gethomepage.dev/description: Chat
+    gethomepage.dev/group: Services
+    #gethomepage.dev/app: coroot-coroot # optional, may be needed if app.kubernetes.io/name != ingress metadata.name
+    gethomepage.dev/name: Matrix
+    #gethomepage.dev/pod-selector: "app.kubernetes.io/part-of=coroot"
+spec:
+  entryPoints:
+    - websecure
+  routes:
+    - kind: Rule
+      match: Host(`matrix.scalar.cloud`)
+      priority: 10
+      services:
+        - name: prod-matrix
+          kind: Service
+          namespace: matrix
+          port: http
+  tls:
+    secretName: matrix-tls
+---
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: matrix
+  namespace: matrix
+spec:
+  secretName: matrix-tls
+  dnsNames:
+    - "matrix.scalar.cloud"
+  issuerRef:
+    name: le-prod
+    kind: ClusterIssuer


### PR DESCRIPTION
Adds a Traefik IngressRoute for Matrix.

This configuration exposes the Matrix service via Traefik,
securing it with TLS using a cert-manager Certificate resource.

It also configures gethomepage.dev annotations.
