### PR TITLE
Adds pre-sync hook for secret creation

### DIFF
--- a/apps/matrix.yaml
+++ b/apps/matrix.yaml
@@ -114,7 +114,8 @@ spec:
           # If true, a job will be run to create the secret if it doesn't exist
           generate: true
           # Additional annotations for the job creating the secret (if generate is true)
-          jobAnnotations: { }
+          jobAnnotations:
+            argocd.argoproj.io/hook: PreSync
 
         # This creates a headless service for metrics collection
         metrics:


### PR DESCRIPTION
Ensures that the secret creation job runs before other resources are synchronized.

This prevents issues where other resources depend on the secret, but the secret is not yet available when they are created.
