### PR TITLE
🔄 Updates ArgoCD hook to "Sync"

### DIFF
--- a/apps/matrix.yaml
+++ b/apps/matrix.yaml
@@ -115,7 +115,7 @@ spec:
           generate: true
           # Additional annotations for the job creating the secret (if generate is true)
           jobAnnotations:
-            argocd.argoproj.io/hook: PreSync
+            argocd.argoproj.io/hook: Sync
 
         # This creates a headless service for metrics collection
         metrics:


### PR DESCRIPTION
Updates the ArgoCD hook annotation for the job creating the secret to "Sync".

This ensures the job runs during the synchronization process, enabling timely updates and proper handling of secrets within the application.
