### PR TITLE
Enables PostgreSQL for Matrix

### DIFF
--- a/apps/matrix.yaml
+++ b/apps/matrix.yaml
@@ -190,6 +190,19 @@ spec:
               m.homeserver:
                 base_url: https://matrix.scalar.cloud/
                 server_name: Matrix
+        postgresql:
+          enabled: true
+          auth:
+            username: matrix
+            database: matrix
+          primary:
+            initdb:
+              args: --encoding=UTF8
+            extraEnvVars:
+              - name: LC_COLLATE
+                value: C
+              - name: LC_CTYPE
+                value: C
   project: default
   syncPolicy:
     automated:


### PR DESCRIPTION
Enables the PostgreSQL database for the Matrix application.

This configuration includes setting up the database user, database name, and initialization arguments. It also sets the locale to "C" to avoid collation issues.
