### PR TITLE
Reverts to stable ESS chart version

### DIFF
--- a/apps/ess.yaml
+++ b/apps/ess.yaml
@@ -9,7 +9,7 @@ spec:
     namespace: matrix
   source:
     repoURL: ghcr.io/element-hq/ess-helm
-    targetRevision: 25.5.2-dev
+    targetRevision: 25.5.1
     chart: matrix-stack
     helm:
       releaseName: prod


### PR DESCRIPTION
Updates the ESS Helm chart target revision to a stable release.

The previous version was a development build and this commit
reverts back to a known stable version.
