### PR TITLE
Sets default timezone

### DIFF
--- a/apps/n8n.yaml
+++ b/apps/n8n.yaml
@@ -25,6 +25,7 @@ spec:
           config:
             n8n:
               editor_base_url: *url
+              generic_timezone: "America/Chicago"
             executions_mode: queue
             db:
               type: postgresdb


### PR DESCRIPTION
Ensures consistent time handling across the application by explicitly setting a default timezone. This avoids potential issues caused by relying on server defaults.
