### PR TITLE
Updates Ollama chart to version 1.26.0

### DIFF
--- a/apps/ollama.yaml
+++ b/apps/ollama.yaml
@@ -9,7 +9,7 @@ spec:
     namespace: ai
   source:
     repoURL: https://otwld.github.io/ollama-helm/
-    targetRevision: 1.20.0
+    targetRevision: 1.26.0
     chart: ollama
     helm:
       releaseName: prod


### PR DESCRIPTION
Bumps the Ollama Helm chart version to the latest stable release.

This ensures access to the newest features, improvements, and bug fixes provided by the Ollama project.
