### PR TITLE
Updates Open WebUI chart to 7.0.1

### DIFF
--- a/apps/open-webui.yaml
+++ b/apps/open-webui.yaml
@@ -9,7 +9,7 @@ spec:
     namespace: ai
   source:
     repoURL: https://helm.openwebui.com/
-    targetRevision: 6.22.0
+    targetRevision: 7.0.1
     chart: open-webui
     helm:
       releaseName: prod
@@ -45,7 +45,7 @@ spec:
 
         tika:
           # -- Automatically install Apache Tika to extend Open WebUI
-          enabled: true
+          enabled: false
 
         # -- A list of Ollama API endpoints. These can be added in lieu of automatically installing the Ollama Helm chart, or in addition to it.
         ollamaUrls: [ "http://prod-ollama.ai:11434" ]


### PR DESCRIPTION
Updates the Open WebUI Helm chart to version 7.0.1.

Disables the automatic installation of Apache Tika. This change likely reflects a configuration update where Tika is no longer desired as a managed dependency.
