### PR TITLE
Updates image pull policy to Always

### DIFF
--- a/foundryvtt/deployment.yaml
+++ b/foundryvtt/deployment.yaml
@@ -116,7 +116,7 @@ spec:
             failureThreshold: 3
           terminationMessagePath: /dev/termination-log
           terminationMessagePolicy: File
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           securityContext: {}
       restartPolicy: Always
       terminationGracePeriodSeconds: 30


### PR DESCRIPTION
Ensures the latest image is always pulled when a pod is created or restarted.
This prevents issues caused by using outdated images, especially after updates to the container image.
