### PR TITLE
🔧 Replaces EMAIL_USE_SSL with EMAIL_USE_TLS in Tandoor deployment

### DIFF
--- a/tandoor/deployment-web.yaml
+++ b/tandoor/deployment-web.yaml
@@ -49,33 +49,6 @@ spec:
                 secretKeyRef:
                   name: recipes
                   key: postgresql-postgres-password
-            - name: EMAIL_USE_SSL
-              valueFrom:
-                secretKeyRef:
-                  name: recipes
-                  key: email-use-tls
-            - name: DEFAULT_FROM_EMAIL
-              value: "tandoor@scalar.cloud"
-            - name: EMAIL_HOST
-              valueFrom:
-                secretKeyRef:
-                  name: recipes
-                  key: email-host
-            - name: EMAIL_PORT
-              valueFrom:
-                secretKeyRef:
-                  name: recipes
-                  key: email-port
-            - name: EMAIL_HOST_USER
-              valueFrom:
-                secretKeyRef:
-                  name: recipes
-                  key: email-host-user
-            - name: EMAIL_HOST_PASSWORD
-              valueFrom:
-                secretKeyRef:
-                  name: recipes
-                  key: email-host-password
           image: vabene1111/recipes
           imagePullPolicy: Always
           resources:
@@ -202,6 +175,33 @@ spec:
                 secretKeyRef:
                   name: recipes
                   key: postgresql-postgres-password
+            - name: EMAIL_USE_TLS
+              valueFrom:
+                secretKeyRef:
+                  name: recipes
+                  key: email-use-tls
+            - name: DEFAULT_FROM_EMAIL
+              value: "tandoor@scalar.cloud"
+            - name: EMAIL_HOST
+              valueFrom:
+                secretKeyRef:
+                  name: recipes
+                  key: email-host
+            - name: EMAIL_PORT
+              valueFrom:
+                secretKeyRef:
+                  name: recipes
+                  key: email-port
+            - name: EMAIL_HOST_USER
+              valueFrom:
+                secretKeyRef:
+                  name: recipes
+                  key: email-host-user
+            - name: EMAIL_HOST_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: recipes
+                  key: email-host-password
           securityContext:
             runAsUser: 65534
       volumes:


### PR DESCRIPTION
Moves the email configuration environment variables between container definitions and updates the SSL variable name to use TLS.
